### PR TITLE
Update dehomogenization and visualization

### DIFF
--- a/scripts/py3/scLocalDB.py
+++ b/scripts/py3/scLocalDB.py
@@ -1,453 +1,578 @@
 # -*- coding: utf-8 -*-
 
-#from abaqusConstants import *
 from abaqusGui import *
-#from kernelAccess import mdb, session
+# from kernelAccess import mdb, session
 import os
 
 thisPath = os.path.abspath(__file__)
-thisDir = os.path.dirname(thisPath)
+thisDir  = os.path.dirname(thisPath)
 
+# Show only CAE SGs that have a real .sc in the work directory =====
+def _resolve_sc_for_sg(sg, sg_name):
+    """Return absolute path to the .sc that should be used for this SG, or None."""
+    try:
+        cwd = os.getcwd()
+        swift = getattr(sg, 'swiftcomp_filename', None)
+
+        # 1) <swiftcomp_filename>.sc in work dir (by basename)
+        if swift:
+            p = os.path.join(cwd, os.path.basename(swift) + '.sc')
+            if os.path.isfile(p):
+                return os.path.abspath(p)
+
+        # 2) <sg_name>.sc in work dir
+        p2 = os.path.join(cwd, sg_name + '.sc')
+        if os.path.isfile(p2):
+            return os.path.abspath(p2)
+    except:
+        pass
+    return None
+
+def _valid_cae_sg_names():
+    """Return sorted SG names that have a resolvable .sc file in the current work dir."""
+    try:
+        names = []
+        for name, sg in mdb.customData.sgs.items():
+            if _resolve_sc_for_sg(sg, name):
+                names.append(name)
+        return sorted(names)
+    except:
+        return []
+# =========================================================================================
 
 ###########################################################################
-# Class definition
+# Dialog
 ###########################################################################
 
 class LocalDB(AFXDataDialog):
-    
-    # [
-    #     ID_Macro1D, 
-    #     ID_Macro2D, 
-    #     ID_Macro3D, 
-    #     ID_AnalysisNonThermal, 
-    #     ID_AnalysisThermal, 
-    #     ID_LAST
-    # ] = range(AFXToolsetGui.ID_LAST, AFXToolsetGui.ID_LAST + 6)
 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def __init__(self, form):
 
-        # Construct the base class.
-        #
+        AFXDataDialog.__init__(
+            self, form, 'Dehomogenization',
+            self.OK | self.CANCEL, DIALOG_ACTIONS_SEPARATOR
+        )
 
-        AFXDataDialog.__init__(self, form, 'Dehomogenization',
-            self.OK|self.CANCEL, DIALOG_ACTIONS_SEPARATOR)
+        # Make the window resizable and big enough that OK/Cancel are visible
+        try:
+            self.setDecorations(self.getDecorations() | DECOR_RESIZE)
+        except: pass
+        try:
+            self.resize(max(self.getDefaultWidth(), 560), 760)
+        except: pass
+
         self.form = form
-        w = 100  # width of table columns
+        colw = 100  # AFXTable column width
 
-        okBtn = self.getActionButton(self.ID_CLICKED_OK)
-        okBtn.setText('OK')
-        
-        GroupBox_0 = FXGroupBox(p=self, text='SG model source',
-                                opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        hf_source = FXHorizontalFrame(p=GroupBox_0, opts=0, x=0, y=0, w=0, h=0,
-                                      pl=0, pr=0, pt=0, pb=0)
-        
-        FXRadioButton(p=hf_source, text='CAE',
-                      tgt=form.sgmodel_sourceKw, sel=1)
-        FXRadioButton(p=hf_source, text='SwiftComp Input file',
-                      tgt=form.sgmodel_sourceKw, sel=2)
-        
-        
-        self.swt_source = FXSwitcher(self, LAYOUT_FILL_X,
-                                     0, 0, 0, 0, 0, 0, 0, 0)
-        
-        #--------------------------------------------------------------------
-        # if sgmodel_sourceKw==1:  from CAE
-        listVf = FXVerticalFrame(
-            p=self.swt_source,
-            opts=FRAME_SUNKEN|FRAME_THICK|LAYOUT_FILL_X, 
-            x=0, y=0, w=0, h=0, pl=0, pr=0, pt=0, pb=0)
-            
-        # Note: Set the selector to indicate that this widget should not be
-        #       colored differently from its parent when the 'Color layout managers'
-        #       button is checked in the RSG Dialog Builder dialog.
-        listVf.setSelector(99)
+        # Remember last error so we don't spam dialogs
+        self._last_error_key = None
+        self._last_sg_name   = ''  # to detect selection changes
+        self._last_source    = None  # to detect CAE/SC switching
+
+        # ---------------- Top controls (non-scrolling) ----------------
+        srcGB = FXGroupBox(self, 'SG model source', FRAME_GROOVE | LAYOUT_FILL_X)
+        hf    = FXHorizontalFrame(srcGB, 0, 0,0,0,0, 0,0,0,0)
+        FXRadioButton(hf, 'CAE',                   self.form.sgmodel_sourceKw, 1)
+        FXRadioButton(hf, 'SwiftComp Input file',  self.form.sgmodel_sourceKw, 2)
+
+        self.swt_source = FXSwitcher(self, LAYOUT_FILL_X, 0,0,0,0, 0,0,0,0)
+
+        # ===== CAE PANEL =====
+        caeVF = FXVerticalFrame(self.swt_source, FRAME_SUNKEN|FRAME_THICK|LAYOUT_FILL_X)
+        caeVF.setSelector(99)
+
         self.List_sg = AFXList(
-            p=listVf, nvis=8, tgt=form.sg_nameKw, sel=0, 
-            opts=HSCROLLING_OFF|LIST_SINGLESELECT|LAYOUT_FILL_X)
-        
-#        msgCount = 169
-#        form.model_nameKw.setTarget(self)
-#        form.model_nameKw.setSelector(AFXDataDialog.ID_LAST+msgCount)
-#        msgHandler = str(self.__class__).split('.')[-1] + '.onComboBox_1PartsChanged'
-#        exec('FXMAPFUNC(self, SEL_COMMAND, AFXDataDialog.ID_LAST+%d, %s)' % (msgCount, msgHandler) )
-        
-        
-        names = list(mdb.customData.sgs.keys())
-        names.sort()
-        for name in names:
-            self.List_sg.appendItem(name)
-        
-        if not form.sg_nameKw.getValue() in names:
-            if len(names) !=0:
-                form.sg_nameKw.setValue( names[0] )
-        else:
-            form.sg_nameKw.setValue('')
-        
-        
-        
-        #----------------------------------------------------------------------
-        # if sgmodel_sourceKw==2:  from SwiftComp Input file
-        VFrame_1 = FXVerticalFrame(
-            p=self.swt_source,
-            opts=0, x=0, y=0, w=0, h=0, pl=0, pr=0, pt=0, pb=0)
-        VAligner_1 = AFXVerticalAligner(
-            p=VFrame_1,
-            opts=0, x=0, y=0, w=0, h=0, pl=0, pr=0, pt=0, pb=0)
-        fileHandler = LocalDBFileHandler(form, 'sc_input', 'SC Input (*.sc)')
-        fileTextHf = FXHorizontalFrame(
-            p=VAligner_1,
-            opts=0, x=0, y=0, w=0, h=0, pl=0, pr=0, pt=0, pb=0,
-            hs=DEFAULT_SPACING, vs=DEFAULT_SPACING)
-        # Note: Set the selector to indicate that this widget should not be
-        #       colored differently from its parent when the 'Color layout managers'
-        #       button is checked in the RSG Dialog Builder dialog.
-        fileTextHf.setSelector(99)
-        AFXTextField(
-            p=fileTextHf, ncols=26, labelText='SwiftComp input file: ',
-            tgt=form.sc_inputKw, sel=0,
-            opts=AFXTEXTFIELD_STRING|LAYOUT_CENTER_Y)
+            caeVF, nvis=8, tgt=self.form.sg_nameKw, sel=0,
+            opts=HSCROLLING_OFF | LIST_SINGLESELECT | LAYOUT_FILL_X
+        )
+
+        # CAE: user controls only strain/stress (uses SAME keyword as SC)
+        self.ComboBox_measure_cae = AFXComboBox(
+            caeVF, ncols=28, nvis=1, text='Generalized strain/stress: ',
+            tgt=self.form.load_measureKw, sel=0
+        )
+        self.ComboBox_measure_cae.setMaxVisible(2)
+        self.ComboBox_measure_cae.appendItem('Strain', 1)
+        self.ComboBox_measure_cae.appendItem('Stress', 0)
+
+        # Populate CAE list with only SGs that have a real .sc in work dir
+        self._refresh_sg_list()
+        # --------------------------------------------------------------------------
+
+        # ===== SwiftComp PANEL =====
+        scVF  = FXVerticalFrame(self.swt_source)
+        align = AFXVerticalAligner(scVF)
+
+        fh = LocalDBFileHandler(self.form, 'sc_input', 'SC Input (*.sc)')
+        fileHF = FXHorizontalFrame(align, hs=DEFAULT_SPACING, vs=DEFAULT_SPACING)
+        fileHF.setSelector(99)
+        AFXTextField(fileHF, 26, 'SwiftComp input file: ',
+                     self.form.sc_inputKw, 0, AFXTEXTFIELD_STRING | LAYOUT_CENTER_Y)
         icon = afxGetIcon('fileOpen', AFX_ICON_SMALL)
-        FXButton(p=fileTextHf, text='\tSelect File\nFrom Dialog',
-                 ic=icon, tgt=fileHandler, sel=AFXMode.ID_ACTIVATE,
-                 opts=BUTTON_NORMAL|LAYOUT_CENTER_Y,
-                 x=0, y=0, w=0, h=0, pl=1, pr=1, pt=1, pb=1)
+        FXButton(fileHF, '\tSelect File\nFrom Dialog', icon, fh,
+                 AFXMode.ID_ACTIVATE, BUTTON_NORMAL | LAYOUT_CENTER_Y, 0,0,0,0,1,1,1,1)
 
-        # ----Analysis type--------
-        ComboBox_4 = AFXComboBox(
-            p=VAligner_1, ncols=28, nvis=1, text='Analysis type: ', 
-            tgt=form.analysisKw, sel=0)
-        ComboBox_4.setMaxVisible(10)
-        ComboBox_4.appendItem(text='Elastic', sel=0)
-        ComboBox_4.appendItem(text='ThermoElastic', sel=1)
-        ComboBox_4.appendItem(text='Conduction', sel=2)
-        ComboBox_4.appendItem(text='PiezoElectric', sel=3)
-        ComboBox_4.appendItem(text='PiezoMagnetic', sel=33)
-        ComboBox_4.appendItem(text='ThermoPiezoElectric', sel=4)
-        ComboBox_4.appendItem(text='ThermoPiezoMagnetic', sel=44)
-        ComboBox_4.appendItem(text='PiezoElectroMagnetic', sel=5)
-        ComboBox_4.appendItem(text='ThermoPiezoElectroMagnetic', sel=6)
-        # ------------------------------------------------------------
-        ComboBox_1 = AFXComboBox(
-            p=VAligner_1, ncols=28, nvis=1, text='Macroscopic model: ',
-            tgt=form.macro_modelKw, sel=0)
-        ComboBox_1.setMaxVisible(10)
-        ComboBox_1.appendItem(text='1D (Beam)', sel=1)
-        ComboBox_1.appendItem(text='2D (Shell)', sel=2)
-        ComboBox_1.appendItem(text='3D (Solid)', sel=3)
+        # Analysis type
+        cb_ana = AFXComboBox(align, 28, 1, 'Analysis type: ', self.form.analysisKw, 0)
+        cb_ana.setMaxVisible(10)
+        cb_ana.appendItem('Elastic', 0)
+        cb_ana.appendItem('ThermoElastic', 1)
+        cb_ana.appendItem('Conduction', 2)
+        cb_ana.appendItem('PiezoElectric', 3)
+        cb_ana.appendItem('PiezoMagnetic', 33)
+        cb_ana.appendItem('ThermoPiezoElectric', 4)
+        cb_ana.appendItem('ThermoPiezoMagnetic', 44)
+        cb_ana.appendItem('PiezoElectroMagnetic', 5)
+        cb_ana.appendItem('ThermoPiezoElectroMagnetic', 6)
 
-        FXCheckButton(p=VFrame_1, text='Aperiodic',
-                      tgt=form.ap_flagKw, sel=0)
+        # Macro model
+        self.cb_macro = AFXComboBox(align, 28, 1, 'Macroscopic model: ', self.form.macro_modelKw, 0)
+        self.cb_macro.setMaxVisible(10)
+        self.cb_macro.appendItem('1D (Beam)', 1)
+        self.cb_macro.appendItem('2D (Shell)', 2)
+        self.cb_macro.appendItem('3D (Solid)', 3)
 
-        FXHorizontalSeparator(p=self, x=0, y=0, w=0, h=0,
-                              pl=2, pr=2, pt=2, pb=2)
-        
-        # -------------------------------------------------------------------
-        # Macroscopic results -----------------------------------------------
-        l = FXLabel(p=self, text='Macroscopic analysis results', opts=JUSTIFY_LEFT)
-        l.setFont( getAFXFont(FONT_BOLD) )
-        
-        # Displacements......................................................
-        gb_v = FXGroupBox(
-            p=self, text='Displacements',
-            opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        vf_v = FXVerticalFrame(
-            gb_v, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_v = AFXTable(vf_v, 2, 3, 2, 3, form.vKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_v.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_v.setLeadingRows(1)
-        t_v.setLeadingRowLabels('v1\tv2\tv3')
-        t_v.setColumnWidth(-1, w)
-        t_v.setColumnJustify(-1, AFXTable.RIGHT)
-        t_v.showHorizontalGrid(True)
-        t_v.showVerticalGrid(True)
-        
-        # Rotations..........................................................
-        gb_c = FXGroupBox(p=self, text='Rotations', opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        vf_c = FXVerticalFrame(
-            gb_c, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_c = AFXTable(vf_c, 3, 3, 2, 3, form.cKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_c.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_c.setColumnWidth(-1, w)
-        t_c.setColumnJustify(-1, AFXTable.RIGHT)
-        t_c.showHorizontalGrid(True)
-        t_c.showVerticalGrid(True)
-        
-        # Generalized strains................................................
-        gb_e = FXGroupBox(p=self, text='Generalized strains',
-                          opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        self.swt_drs = FXSwitcher(gb_e, 0, 0,0,0,0, 0,0,0,0)
-        # 1D........
-        vf_1d = FXVerticalFrame(self.swt_drs, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        vf_be = FXVerticalFrame(
-            vf_1d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_be = AFXTable(vf_be, 2, 1, 2, 1, form.beKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_be.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_be.setLeadingRows(1)
-        t_be.setLeadingRowLabels('epsilon11')
-        t_be.setColumnWidth(-1, w)
-        t_be.setColumnJustify(-1, AFXTable.RIGHT)
-        t_be.showHorizontalGrid(True)
-        t_be.showVerticalGrid(True)
+        # Measure (same keyword as CAE)
+        self.cb_measure_sc = AFXComboBox(
+            align, 28, 1, 'Generalized strain/stress: ', self.form.load_measureKw, 0)
+        self.cb_measure_sc.setMaxVisible(2)
+        self.cb_measure_sc.appendItem('Strain', 1)
+        self.cb_measure_sc.appendItem('Stress', 0)
 
-        vf_bk = FXVerticalFrame(
-            vf_1d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_bk = AFXTable(vf_bk, 2, 3, 2, 3, form.bkKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_bk.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_bk.setLeadingRows(1)
-        t_bk.setLeadingRowLabels('kappa11\tkappa12\tkappa13')
-        t_bk.setColumnWidth(-1, w)
-        t_bk.setColumnJustify(-1, AFXTable.RIGHT)
-        t_bk.showHorizontalGrid(True)
-        t_bk.showVerticalGrid(True)
-        
-        # 2D........
-        vf_2d = FXVerticalFrame(self.swt_drs, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        vf_se = FXVerticalFrame(
-            vf_2d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_se = AFXTable(vf_se, 2, 3, 2, 3, form.seKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_se.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_se.setLeadingRows(1)
-        t_se.setLeadingRowLabels('epsilon11\t2epsilon12\tepsilon22')
-        t_se.setColumnWidth(-1, w)
-        t_se.setColumnJustify(-1, AFXTable.RIGHT)
-        t_se.showHorizontalGrid(True)
-        t_se.showVerticalGrid(True)
+        # Beam/Shell type rows (SwiftComp only; CAE deduces automatically)
+        self.beamRow  = FXHorizontalFrame(align);  self.beamRow.hide()
+        self.cb_beam  = AFXComboBox(self.beamRow, 28, 1, 'Beam model: ', self.form.beam_modelKw, 0)
+        self.cb_beam.setMaxVisible(2)
+        self.cb_beam.appendItem('Euler', 1)
+        self.cb_beam.appendItem('Timoshenko', 2)
 
-        vf_sk = FXVerticalFrame(
-            vf_2d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_sk = AFXTable(vf_sk, 2, 3, 2, 3, form.skKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_sk.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_sk.setLeadingRows(1)
-        t_sk.setLeadingRowLabels('kappa11\tkappa12+21\tkappa22')
-        t_sk.setColumnWidth(-1, w)
-        t_sk.setColumnJustify(-1, AFXTable.RIGHT)
-        t_sk.showHorizontalGrid(True)
-        t_sk.showVerticalGrid(True)
-        
-        # 3D........
-        vf_3d = FXVerticalFrame(self.swt_drs, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        vf_en = FXVerticalFrame(
-            vf_3d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_en = AFXTable(vf_en, 2, 3, 2, 3, form.enKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_en.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_en.setLeadingRows(1)
-        t_en.setLeadingRowLabels('epsilon11\tepsilon22\tepsilon33')
-        t_en.setColumnWidth(-1, w)
-        t_en.setColumnJustify(-1, AFXTable.RIGHT)
-        t_en.showHorizontalGrid(True)
-        t_en.showVerticalGrid(True)
+        self.shellRow = FXHorizontalFrame(align);  self.shellRow.hide()
+        self.cb_shell = AFXComboBox(self.shellRow, 28, 1, 'Shell model: ', self.form.shell_modelKw, 0)
+        self.cb_shell.setMaxVisible(2)
+        self.cb_shell.appendItem('Kirchhoff', 1)
+        self.cb_shell.appendItem('Mindlin',  2)
 
-        vf_es = FXVerticalFrame(
-            vf_3d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_es = AFXTable(vf_es, 2, 3, 2, 3, form.esKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_es.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_es.setLeadingRows(1)
-        t_es.setLeadingRowLabels('2epsilon23\t2epsilon13\t2epsilon12')
-        t_es.setColumnWidth(-1, w)
-        t_es.setColumnJustify(-1, AFXTable.RIGHT)
-        t_es.showHorizontalGrid(True)
-        t_es.showVerticalGrid(True)
-        
-        # Additional inputs................................................
-        GroupBox_4 = FXGroupBox(p=self, text='Additional inputs',
-                                opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        
-        # temperature........
-        HFrame_6=FXHorizontalFrame(p=GroupBox_4, opts=LAYOUT_FILL_X, x=0, y=0, w=0, h=0,
-            pl=0, pr=0, pt=0, pb=0)
-        VAligner_14 = AFXVerticalAligner(p=HFrame_6, opts=0, x=0, y=0, w=0, h=0,
-            pl=0, pr=0, pt=0, pb=0)
-        self.tempdiff = AFXTextField(
-            p=VAligner_14, ncols=12, labelText='temperature increment',
-            tgt=form.tmKw, sel=0)
+        FXCheckButton(scVF, 'Aperiodic', self.form.ap_flagKw, 0)
 
-        
-        #---------------------------------------------------------------------
-        
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_Macro1D, LocalDB.onMacro1D)
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_Macro2D, LocalDB.onMacro2D)
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_Macro3D, LocalDB.onMacro3D)
-        
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_AnalysisNonThermal,
-        #           LocalDB.onAnalysisNonThermal)
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_AnalysisThermal,
-        #           LocalDB.onAnalysisThermal)
-        
-        # self.addTransition(
-        #     form.macro_modelKw, AFXTransition.EQ, 1, self,
-        #     MKUINT(self.ID_Macro1D, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.macro_modelKw, AFXTransition.EQ, 2, self,
-        #     MKUINT(self.ID_Macro2D, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.macro_modelKw, AFXTransition.EQ, 3, self,
-        #     MKUINT(self.ID_Macro3D, SEL_COMMAND), None)
-                           
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 0, self,
-        #     MKUINT(self.ID_AnalysisNonThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 2, self,
-        #     MKUINT(self.ID_AnalysisNonThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 3, self,
-        #     MKUINT(self.ID_AnalysisNonThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 5, self,
-        #     MKUINT(self.ID_AnalysisNonThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 1, self,
-        #     MKUINT(self.ID_AnalysisThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 4, self,
-        #     MKUINT(self.ID_AnalysisThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 6, self,
-        #     MKUINT(self.ID_AnalysisThermal, SEL_COMMAND), None)
+        FXHorizontalSeparator(self, 2,2,2,2)
 
-    
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # ---------------- Scrolling content ----------------
+        scroll  = FXScrollWindow(self, LAYOUT_FILL_X|LAYOUT_FILL_Y|VSCROLLER_ALWAYS|HSCROLLER_NEVER)
+        content = FXVerticalFrame(scroll, FRAME_NONE|LAYOUT_FILL_X|LAYOUT_FILL_Y)
+
+        # Title
+        t = FXLabel(p=content, text='Macroscopic analysis results', opts=JUSTIFY_LEFT)
+        t.setFont(getAFXFont(FONT_BOLD))
+
+        # Displacements
+        gb_v = FXGroupBox(content, 'Displacements', FRAME_GROOVE|LAYOUT_FILL_X)
+        vf_v = FXVerticalFrame(gb_v, FRAME_SUNKEN|FRAME_THICK)
+        tv   = AFXTable(vf_v, 2,3, 2,3, self.form.vKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tv.setLeadingRows(1); tv.setLeadingRowLabels('v1\tv2\tv3')
+        tv.setColumnWidth(-1, colw); tv.setColumnJustify(-1, AFXTable.RIGHT)
+        tv.showHorizontalGrid(True); tv.showVerticalGrid(True)
+
+        # Rotations
+        gb_c = FXGroupBox(content, 'Rotations', FRAME_GROOVE|LAYOUT_FILL_X)
+        vf_c = FXVerticalFrame(gb_c, FRAME_SUNKEN|FRAME_THICK)
+        tc   = AFXTable(vf_c, 3,3, 2,3, self.form.cKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tc.setColumnWidth(-1, colw); tc.setColumnJustify(-1, AFXTable.RIGHT)
+        tc.showHorizontalGrid(True); tc.showVerticalGrid(True)
+
+        # Generalized inputs (switchers)
+        gb_g   = FXGroupBox(content, 'Generalized inputs', FRAME_GROOVE|LAYOUT_FILL_X)
+        self.swt_dim = FXSwitcher(gb_g)  # 1D / 2D / 3D
+
+        # 1D switcher: 0 Euler strain, 1 Euler stress, 2 Timo strain, 3 Timo stress
+        f1d = FXVerticalFrame(self.swt_dim)
+        self.swt_1d = FXSwitcher(f1d)
+
+        # Euler STRAIN: be=[ε11], bk=[κ11 κ12 κ13]
+        f_1d_es = FXVerticalFrame(self.swt_1d)
+        vf = FXVerticalFrame(f_1d_es, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,1, 2,1, self.form.beKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11')
+        vf2 = FXVerticalFrame(f_1d_es, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.bkKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('kappa11\tkappa12\tkappa13')
+
+        # Euler STRESS: be=[F1], bk=[M1 M2 M3]
+        f_1d_eF = FXVerticalFrame(self.swt_1d)
+        vf = FXVerticalFrame(f_1d_eF, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,1, 2,1, self.form.beKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('F1')
+        vf2 = FXVerticalFrame(f_1d_eF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.bkKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('M1\tM2\tM3')
+
+        # Timoshenko STRAIN: be=[ε11 γ12 γ13], bk=[κ11 κ12 κ13]
+        f_1d_ts = FXVerticalFrame(self.swt_1d)
+        vf = FXVerticalFrame(f_1d_ts, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.beKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11\tgamma12\tgamma13')
+        vf2 = FXVerticalFrame(f_1d_ts, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.bkKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('kappa11\tkappa12\tkappa13')
+
+        # Timoshenko STRESS: be=[F1 F2 F3], bk=[M1 M2 M3]
+        f_1d_tF = FXVerticalFrame(self.swt_1d)
+        vf = FXVerticalFrame(f_1d_tF, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.beKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('F1\tF2\tF3')
+        vf2 = FXVerticalFrame(f_1d_tF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.bkKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('M1\tM2\tM3')
+
+        # 2D switcher: 0 KL strain, 1 KL stress, 2 Mindlin strain, 3 Mindlin stress
+        f2d = FXVerticalFrame(self.swt_dim)
+        self.swt_2d = FXSwitcher(f2d)
+
+        # Kirchhoff STRAIN
+        f_2d_ks = FXVerticalFrame(self.swt_2d)
+        vf = FXVerticalFrame(f_2d_ks, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.seKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11\t2epsilon12\tepsilon22')
+        vf2 = FXVerticalFrame(f_2d_ks, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.skKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('kappa11\t2kappa12\tkappa22')
+
+        # Kirchhoff STRESS
+        f_2d_kF = FXVerticalFrame(self.swt_2d)
+        vf = FXVerticalFrame(f_2d_kF, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.seKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('N11\tN22\tN12')
+        vf2 = FXVerticalFrame(f_2d_kF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.skKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('M11\tM22\tM12')
+
+        # Mindlin STRAIN (adds γ13 γ23 in esKw)
+        f_2d_ms = FXVerticalFrame(self.swt_2d)
+        vf = FXVerticalFrame(f_2d_ms, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.seKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11\t2epsilon12\tepsilon22')
+        vf2 = FXVerticalFrame(f_2d_ms, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.skKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('kappa11\t2kappa12\tkappa22')
+        vf3 = FXVerticalFrame(f_2d_ms, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf3, 2,2, 2,2, self.form.esKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('gamma13\tgamma23')
+
+        # Mindlin STRESS (adds N13 N23 in esKw)
+        f_2d_mF = FXVerticalFrame(self.swt_2d)
+        vf = FXVerticalFrame(f_2d_mF, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.seKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('N11\tN22\tN12')
+        vf2 = FXVerticalFrame(f_2d_mF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.skKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('M11\tM22\tM12')
+        vf3 = FXVerticalFrame(f_2d_mF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf3, 2,2, 2,2, self.form.esKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('N13\tN23')
+
+        # 3D switcher: 0 strain, 1 stress
+        f3d = FXVerticalFrame(self.swt_dim)
+        self.swt_3d = FXSwitcher(f3d)
+
+        f_3d_s = FXVerticalFrame(self.swt_3d)
+        vf = FXVerticalFrame(f_3d_s, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.enKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11\tepsilon22\tepsilon33')
+        vf2 = FXVerticalFrame(f_3d_s, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.esKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('2epsilon23\t2epsilon13\t2epsilon12')
+
+        f_3d_F = FXVerticalFrame(self.swt_3d)
+        vf = FXVerticalFrame(f_3d_F, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.enKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('sigma11\tsigma22\tsigma33')
+        vf2 = FXVerticalFrame(f_3d_F, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.esKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('sigma23\tsigma13\tsigma12')
+
+        # Additional inputs
+        addGB = FXGroupBox(content, 'Additional inputs', FRAME_GROOVE|LAYOUT_FILL_X)
+        addHF = FXHorizontalFrame(addGB, LAYOUT_FILL_X)
+        addVA = AFXVerticalAligner(addHF)
+        self.tempdiff = AFXTextField(addVA, 12, 'temperature increment', self.form.tmKw, 0)
+
+    # Repopulate the CAE SG list with only valid names --------
+    def _refresh_sg_list(self):
+        try:
+            valid = _valid_cae_sg_names()
+            # clear and repopulate list
+            try:
+                self.List_sg.clearItems()
+            except:
+                pass
+            for nm in valid:
+                self.List_sg.appendItem(nm)
+            # set keyword to first valid (or empty)
+            if valid:
+                if self.form.sg_nameKw.getValue() not in valid:
+                    self.form.sg_nameKw.setValue(valid[0])
+            else:
+                self.form.sg_nameKw.setValue('')
+        except:
+            pass
+    # ----------------------------------------------------------------------
+
+    # -------- Helpers --------
+    def _toggle_specific(self, macro_model_int):
+        if macro_model_int == 1:
+            self.beamRow.show();  self.shellRow.hide()
+        elif macro_model_int == 2:
+            self.beamRow.hide();  self.shellRow.show()
+        else:
+            self.beamRow.hide();  self.shellRow.hide()
+        try:
+            self.beamRow.recalc(); self.shellRow.recalc()
+            self.layout(); self.update()
+        except: pass
+
+    def _error(self, title, msg):
+        try:
+            showAFXErrorDialog(getAFXApp().getAFXMainWindow(), '%s\n\n%s' % (title, msg))
+        except:
+            try:
+                AFXMessageDialog(getAFXApp().getAFXMainWindow(),
+                                 self, AFXMessageDialog.ERROR, title, msg).create().showModal()
+            except:
+                print('[ERROR] %s: %s' % (title, msg))
+
+    # Show an error only once per unique "key"
+    def _error_once(self, title, msg, key):
+        if key == self._last_error_key:
+            return
+        self._last_error_key = key
+        self._error(title, msg)
+
+    def _determine_model_from_cae(self, sg_name):
+        """Return (macro_model_int, model_string). Enforces that a real .sc exists.
+           Uses numeric specific_model when available; falls back to model strings."""
+        # 0) fetch SG
+        try:
+            sg = mdb.customData.sgs[sg_name]
+        except:
+            self._error_once('CAE model',
+                             'Selected SG cannot be found in mdb.customData.sgs.',
+                             key=('missing_sg', sg_name))
+            return (None, None)
+
+        # 1) MUST have a usable .sc file in current work directory
+        sc_path = _resolve_sc_for_sg(sg, sg_name)
+        if not sc_path:
+            self._error_once(
+                'SwiftComp file not found',
+                ("The selected CAE SG requires a matching .sc file in the current work directory.\n"
+                 "Set the work directory to the folder containing the .sc and try again, "
+                 "or re-export homogenization."),
+                key=('missing_sc', sg_name)
+            )
+            return (None, None)
+
+        # 2) dimension
+        try:
+            dim = (getattr(sg, 'macro_model_dimension', '') or '').strip()
+            macro = int(dim.strip('D')) if dim else None
+        except:
+            macro = None
+
+        # 3) prefer numeric specific_model (0/1). fall back to strings.
+        sm = getattr(sg, 'specific_model', None)
+        beam  = (getattr(sg, 'beam_model',  '') or '').strip()
+        shell = (getattr(sg, 'shell_model', '') or '').strip()
+        model = (getattr(sg, 'model',       '') or '').strip()
+        nm = (sg_name or '').lower()
+
+        if macro == 1:
+            # 1D: 0=Euler, 1=Timoshenko
+            if isinstance(sm, (int, long)) if 'long' in dir(__builtins__) else isinstance(sm, int):
+                if sm in (0, 1):
+                    return (1, 'Euler' if sm == 0 else 'Timoshenko')
+            # fallback: strings / name
+            cand = beam or (model if model.lower().startswith(('euler','timo')) else '')
+            if not cand:
+                cand = 'Euler' if 'euler' in nm else ('Timoshenko' if 'timo' in nm else '')
+            if not cand:
+                self._error_once(
+                    'Missing beam model',
+                    'CAE SG is 1D but lacks Euler/Timoshenko info. Re-export with the latest GUI.',
+                    key=('beam_missing', sg_name)
+                ); return (None, None)
+            return (1, 'Euler' if cand.lower().startswith('euler') else 'Timoshenko')
+
+        if macro == 2:
+            # 2D: 0=Kirchhoff, 1=Mindlin
+            if isinstance(sm, (int, long)) if 'long' in dir(__builtins__) else isinstance(sm, int):
+                if sm in (0, 1):
+                    return (2, 'Kirchhoff' if sm == 0 else 'Mindlin')
+            # fallback: strings / name
+            ml = model.lower()
+            cand = shell or (model if ml.startswith(('kirch','mind')) else '')
+            if not cand:
+                cand = 'Kirchhoff' if 'kirch' in nm else ('Mindlin' if ('mind' in nm or 'reissner' in nm) else '')
+            if not cand:
+                self._error_once(
+                    'Missing shell model',
+                    'CAE SG is 2D but lacks Kirchhoff/Mindlin info. Re-export with the latest GUI.',
+                    key=('shell_missing', sg_name)
+                ); return (None, None)
+            return (2, 'Kirchhoff' if cand.lower().startswith('kirch') else 'Mindlin')
+
+        if macro == 3:
+            return (3, '')
+
+        self._error_once(
+            'Unknown macro model',
+            'Could not determine whether the CAE SG is 1D/2D/3D. Re-export with the latest GUI.',
+            key=('macro_unknown', sg_name)
+        )
+        return (None, None)
+
+    # -------- AFXDataDialog overrides --------
     def show(self):
-        
+        # reset error latch every time dialog opens
+        self._last_error_key = None
+        self._last_sg_name   = ''
+        self._last_source    = None
+
+        if self.form.sgmodel_sourceKw.getValue() == 2:
+            self.swt_source.setCurrent(1)
+            self._toggle_specific(self.form.macro_modelKw.getValue())
+        else:
+            self.swt_source.setCurrent(0)
+            self.beamRow.hide(); self.shellRow.hide()
+            # Ensure list is fresh on open in CAE mode
+            self._refresh_sg_list()
+
         self.tempdiff.disable()
-        self.swt_source.setCurrent(0)
         AFXDataDialog.show(self)
 
-        
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    def hide(self):
-
-        AFXDataDialog.hide(self)
-        
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def processUpdates(self):
-        
+        # detect CAE/SC switching; refresh list when CAE is selected
+        try:
+            current_source = self.form.sgmodel_sourceKw.getValue()
+        except:
+            current_source = None
+
+        if current_source != self._last_source:
+            self._last_source = current_source
+            if current_source == 1:  # CAE
+                self._refresh_sg_list()
+
+        # if the selected SG changed, allow a new error to show once
+        sg_now = self.form.sg_nameKw.getValue()
+        if sg_now != self._last_sg_name:
+            self._last_sg_name = sg_now
+            self._last_error_key = None  # clear the latch when user changes selection
+
+        # normalize measure
+        try:
+            measure = int(self.form.load_measureKw.getValue())
+        except:
+            measure = 1 if str(self.form.load_measureKw.getValue()).lower().startswith('strain') else 0
+        is_strain = (measure == 1)
+
         if self.form.sgmodel_sourceKw.getValue() == 1:
+            # -------- CAE mode --------
             self.swt_source.setCurrent(0)
             sg_name = self.form.sg_nameKw.getValue()
-            if sg_name != '':
-                macro_model_d = mdb.customData.sgs[sg_name].macro_model_dimension
-                macro_model = int(macro_model_d.strip('D'))
-                self.swt_drs.setCurrent(macro_model-1)
-                # if macro_model == 1:
-                #     self.swt_drs.setCurrent(0)
-                # elif macro_model == 2:
-                #     self.swt_drs.setCurrent(1)
-                # elif macro_model == 3:
-                #     self.swt_drs.setCurrent(2)
 
-                analysis = mdb.customData.sgs[sg_name].analysis
-                if analysis in [0, 2, 3, 5]:
-                    self.tempdiff.disable()
-                elif analysis in [1, 4, 6]:
-                    self.tempdiff.enable()
+            if not sg_name:
+                self.swt_dim.setCurrent(2)
+                return
+
+            macro, variant = self._determine_model_from_cae(sg_name)
+            if macro is None:
+                return
+
+            self.swt_dim.setCurrent(macro - 1)
+
+            if macro == 1:
+                self.beamRow.hide(); self.shellRow.hide()
+                self.swt_1d.setCurrent(0 if (variant == 'Euler' and is_strain)
+                                       else 1 if (variant == 'Euler' and not is_strain)
+                                       else 2 if (variant == 'Timoshenko' and is_strain)
+                                       else 3)
+            elif macro == 2:
+                self.beamRow.hide(); self.shellRow.hide()
+                self.swt_2d.setCurrent(0 if (variant == 'Kirchhoff' and is_strain)
+                                       else 1 if (variant == 'Kirchhoff' and not is_strain)
+                                       else 2 if (variant == 'Mindlin' and is_strain)
+                                       else 3)
             else:
-                self.swt_drs.setCurrent(2)
-        elif self.form.sgmodel_sourceKw.getValue() == 2:
+                self.beamRow.hide(); self.shellRow.hide()
+                self.swt_3d.setCurrent(0 if is_strain else 1)
+
+            try:
+                analysis = int(getattr(mdb.customData.sgs[sg_name], 'analysis', 0))
+            except:
+                analysis = 0
+            if analysis in (1, 4, 6):
+                self.tempdiff.enable()
+            else:
+                self.tempdiff.disable()
+
+            try:
+                self.swt_1d.recalc(); self.swt_2d.recalc(); self.swt_3d.recalc()
+                self.swt_dim.recalc(); self.layout(); self.update()
+            except: pass
+
+        else:
+            # -------- SwiftComp mode --------
+            # changing source resets error latch
+            if self._last_error_key is not None:
+                self._last_error_key = None
+
             self.swt_source.setCurrent(1)
-            macro_model = self.form.macro_modelKw.getValue()
-            self.swt_drs.setCurrent(macro_model-1)
+            macro = self.form.macro_modelKw.getValue()
+            self._toggle_specific(macro)
+
+            self.swt_dim.setCurrent(macro - 1)
+            if macro == 1:
+                bm = self.form.beam_modelKw.getValue().lower()
+                self.swt_1d.setCurrent(0 if (bm=='euler' and is_strain)
+                                       else 1 if (bm=='euler' and not is_strain)
+                                       else 2 if (bm=='timoshenko' and is_strain)
+                                       else 3)
+            elif macro == 2:
+                sm = self.form.shell_modelKw.getValue().lower()
+                self.swt_2d.setCurrent(0 if (sm=='kirchhoff' and is_strain)
+                                       else 1 if (sm=='kirchhoff' and not is_strain)
+                                       else 2 if (sm in ('mindlin','reissner','reissner–mindlin','reissner-mindlin') and is_strain)
+                                       else 3)
+            else:
+                self.swt_3d.setCurrent(0 if is_strain else 1)
 
             analysis = self.form.analysisKw.getValue()
-            if analysis in [0, 2, 3, 33, 5]:
-                self.tempdiff.disable()
-            elif analysis in [1, 4, 44, 6]:
+            if analysis in (1, 4, 44, 6):
                 self.tempdiff.enable()
-                
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#    def updateComboBox_1Parts(self):
-#
-#        modelName = self.form.model_nameKw.getValue()
-#
-#        # Update the names in the Parts combo
-#        #
-#        self.ComboBox_1.clearItems()
-#        names = mdb.models[modelName].parts.keys()
-#        names.sort()
-#        for name in names:
-#            self.ComboBox_1.appendItem(name)
-#        if names:
-#            if not self.form.part_nameKw.getValue() in names:
-#                self.form.part_nameKw.setValue( names[0] )
-#        else:
-#            self.form.part_nameKw.setValue('')
-#
-#        self.resize( self.getDefaultWidth(), self.getDefaultHeight() )
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onMacro1D(self, sender, sel, ptr):
-    #     
-    #     self.swt_drs.setCurrent(0)
-    #     
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onMacro2D(self, sender, sel, ptr):
-    #     
-    #     self.swt_drs.setCurrent(1)
-    #     
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onMacro3D(self, sender, sel, ptr):
-    #     
-    #     self.swt_drs.setCurrent(2)
-    # 
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onAnalysisNonThermal(self, sender, sel, ptr):
-    #     
-    #     self.tempdiff.disable()
-    #     
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onAnalysisThermal(self, sender, sel, ptr):
-    #     
-    #     self.tempdiff.enable()
-        
-    
+            else:
+                self.tempdiff.disable()
+
+            try:
+                self.swt_1d.layout(); self.swt_2d.layout(); self.swt_3d.layout()
+                self.swt_dim.layout(); self.layout(); self.update()
+            except: pass
+
 ###########################################################################
-# Class definition
+# File selector helper
 ###########################################################################
 
 class LocalDBFileHandler(FXObject):
-
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def __init__(self, form, keyword, patterns='*'):
-
-        self.form = form
-        self.patterns = patterns
-        self.patternTgt = AFXIntTarget(0)
+        self.form      = form
+        self.patterns  = patterns
+        self.patternTgt= AFXIntTarget(0)
         exec('self.fileNameKw = form.%sKw' % keyword)
-        self.readOnlyKw = AFXBoolKeyword(None, 'readOnly', AFXBoolKeyword.TRUE_FALSE)
+        self.readOnlyKw= AFXBoolKeyword(None, 'readOnly', AFXBoolKeyword.TRUE_FALSE)
         FXObject.__init__(self)
         FXMAPFUNC(self, SEL_COMMAND, AFXMode.ID_ACTIVATE, LocalDBFileHandler.activate)
 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def activate(self, sender, sel, ptr):
-
-       fileDb = AFXFileSelectorDialog(getAFXApp().getAFXMainWindow(), 'Select a File',
-           self.fileNameKw, self.readOnlyKw,
-           AFXSELECTFILE_ANY, self.patterns, self.patternTgt)
-       fileDb.setReadOnlyPatterns('*.odb')
-       fileDb.create()
-       fileDb.showModal()
+        dlg = AFXFileSelectorDialog(getAFXApp().getAFXMainWindow(), 'Select a File',
+                                    self.fileNameKw, self.readOnlyKw,
+                                    AFXSELECTFILE_ANY, self.patterns, self.patternTgt)
+        dlg.setReadOnlyPatterns('*.odb')
+        dlg.create()
+        dlg.showModal()

--- a/scripts/py3/scLocalForm.py
+++ b/scripts/py3/scLocalForm.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from abaqusGui import *
-#from abaqusConstants import *
-#import osutils, os
 import scLocalDB
 import importlib
-if importlib.sys.version_info.major < 3: importlib.reload = reload
+if importlib.sys.version_info.major < 3:
+    importlib.reload = reload
 
 
 ###########################################################################
@@ -16,35 +15,38 @@ class LocalForm(AFXForm):
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def __init__(self, owner):
-        
-        # Construct the base class.
-        #
+
         AFXForm.__init__(self, owner)
         self.radioButtonGroups = {}
 
         self.cmd = AFXGuiCommand(
             mode=self, method='localization',
             objectName='scLocalMain', registerQuery=False)
-        pickedDefault = ''
-        self.sgmodel_sourceKw = AFXIntKeyword(
-            self.cmd, 'sgmodel_source', True, 1)
-        self.sg_nameKw = AFXStringKeyword(self.cmd, 'sg_name', True)
-        self.sc_inputKw = AFXStringKeyword(self.cmd, 'sc_input', True, '')
-        self.ap_flagKw = AFXBoolKeyword(
-            self.cmd, 'ap_flag', AFXBoolKeyword.TRUE_FALSE, True, False)
-        self.macro_modelKw = AFXIntKeyword(
-            self.cmd, 'macro_model', True, 3, evalExpression=False)
-        self.analysisKw = AFXIntKeyword(
-            self.cmd, 'analysis', True, 0, evalExpression=False)
 
-        # Displacements
+        # ----- Source selection & file/model fields
+        self.sgmodel_sourceKw = AFXIntKeyword(self.cmd, 'sgmodel_source', True, 2)  # 1=CAE, 2=SC
+        self.sg_nameKw       = AFXStringKeyword(self.cmd, 'sg_name', True)
+        self.sc_inputKw      = AFXStringKeyword(self.cmd, 'sc_input', True, '')
+        self.ap_flagKw       = AFXBoolKeyword(self.cmd, 'ap_flag', AFXBoolKeyword.TRUE_FALSE, True, False)
+
+        # For SC-input mode only (UI decides visibility; values passed to backend)
+        self.macro_modelKw = AFXIntKeyword(self.cmd, 'macro_model', True, 3, evalExpression=False)  # 1,2,3
+        self.analysisKw    = AFXIntKeyword(self.cmd, 'analysis',    True, 0, evalExpression=False)
+
+        # Model sub-options (used only when 1D/2D is chosen in SC mode)
+        self.beam_modelKw  = AFXStringKeyword(self.cmd, 'beam_model',  True, 'Euler')      # Euler / Timoshenko
+        self.shell_modelKw = AFXStringKeyword(self.cmd, 'shell_model', True, 'Kirchhoff')  # Kirchhoff / Mindlin
+
+        # Generalized strain/stress selector (0=stress, 1=strain)
+        self.load_measureKw = AFXIntKeyword(self.cmd, 'load_measure', True, 1, evalExpression=False)
+
+        # Displacements (3) and Rotations (3x3)
         self.vKw = AFXTableKeyword(self.cmd, 'v', True)
         self.vKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
         self.vKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
         self.vKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
         self.vKw.setRow(0, '0.0, 0.0, 0.0')
 
-        # Rotations
         self.cKw = AFXTableKeyword(self.cmd, 'c', True)
         self.cKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
         self.cKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
@@ -53,11 +55,13 @@ class LocalForm(AFXForm):
         self.cKw.setRow(1, '0.0, 1.0, 0.0')
         self.cKw.setRow(2, '0.0, 0.0, 1.0')
 
-        # Strains
-        # 1D
+        # Generalized quantities (tables are reused across views)
+        # 1D: be (ε11 or F1 [+ γ12 γ13 for Timo strain / F2 F3 for stress]), bk (κ11 κ12 κ13 or M1 M2 M3)
         self.beKw = AFXTableKeyword(self.cmd, 'be', True)
         self.beKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
-        self.beKw.setRow(0, '0.0')
+        self.beKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
+        self.beKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
+        self.beKw.setRow(0, '0.0, 0.0, 0.0')
 
         self.bkKw = AFXTableKeyword(self.cmd, 'bk', True)
         self.bkKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
@@ -65,7 +69,7 @@ class LocalForm(AFXForm):
         self.bkKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
         self.bkKw.setRow(0, '0.0, 0.0, 0.0')
 
-        # 2D
+        # 2D: se (membrane 3), sk (bending 3), es reused for Mindlin extra pair or 3D shear triplet
         self.seKw = AFXTableKeyword(self.cmd, 'se', True)
         self.seKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
         self.seKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
@@ -78,7 +82,7 @@ class LocalForm(AFXForm):
         self.skKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
         self.skKw.setRow(0, '0.0, 0.0, 0.0')
 
-        # 3D
+        # 3D: en (normal 3), es (shear 3). For Mindlin extra (N13,N23 or γ13,γ23) we still pass through esKw’s first two entries.
         self.enKw = AFXTableKeyword(self.cmd, 'en', True)
         self.enKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
         self.enKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
@@ -91,24 +95,19 @@ class LocalForm(AFXForm):
         self.esKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
         self.esKw.setRow(0, '0.0, 0.0, 0.0')
 
+        # Temperature increment (used for thermal analyses)
         self.tmKw = AFXFloatKeyword(self.cmd, 'tm', True, 0.0)
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def getFirstDialog(self):
-
-#        import scLocalDB
         importlib.reload(scLocalDB)
         return scLocalDB.LocalDB(self)
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def doCustomChecks(self):
-
-        # Try to set the appropriate radio button on. If the user did
-        # not specify any buttons to be on, do nothing.
-        #
-        for kw1,kw2,d in list(self.radioButtonGroups.values()):
+        for kw1, kw2, d in list(self.radioButtonGroups.values()):
             try:
-                value = d[ kw1.getValue() ]
+                value = d[kw1.getValue()]
                 kw2.setValue(value)
             except:
                 pass
@@ -116,9 +115,4 @@ class LocalForm(AFXForm):
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def okToCancel(self):
-
-        # No need to close the dialog when a file operation (such
-        # as New or Open) or model change is executed.
-        #
         return False
-

--- a/scripts/py3/scLocalMain.py
+++ b/scripts/py3/scLocalMain.py
@@ -18,7 +18,11 @@ def localization(
         sg_name='', sc_input='', analysis=0, macro_model=3,
         load_measure=1,
         be='', bk='', se='', sk='', en='', es='',
-        tm=0.0, ap_flag=False):
+        sh2='',                    # extra 2 components for Mindlin: γ13 γ23 (strain) or N13 N23 (stress)
+        tm=0.0, ap_flag=False,
+        beam_model="Euler",        # Euler or Timoshenko (for 1D)
+        shell_model="Kirchhoff"    # Kirchhoff or Mindlin/Reissner–Mindlin (for 2D)
+    ):
     """
     Localization analysis for a SG model or a SwiftComp input file.
 
@@ -66,24 +70,39 @@ def localization(
     elif en != '' and es != '':
         e = en[0] + es[0]
 
+    # Handle extra Mindlin pair (γ13, γ23) or (N13, N23).
+    # Accept from explicit 'sh2' if provided; otherwise, fall back to es[0][:2] if user entered via es.
+    mindlin_extra = []
+    if isinstance(sh2, (list, tuple)) and len(sh2) > 0:
+        mindlin_extra = list(sh2[0])
+    elif isinstance(es, (list, tuple)) and len(es) > 0:
+        # If GUI provided γ13, γ23 (or N13, N23) via es for Mindlin, take the first two.
+        if isinstance(es[0], (list, tuple)) and len(es[0]) >= 2:
+            mindlin_extra = list(es[0][:2])
+
     mdb.customData.Repository('sgDehomoDataSets', SgDehomoData)
     
-    SCfileName, sc_input, analysis,  macro_model, macro_model_dimension, ap_flag=sgmodel_info(sgmodel_source=sgmodel_source, sg_name=sg_name, sc_input=sc_input,  analysis=analysis, macro_model=macro_model, ap_flag=ap_flag)
+    SCfileName, sc_input, analysis,  macro_model, macro_model_dimension, ap_flag = sgmodel_info(
+        sgmodel_source=sgmodel_source, sg_name=sg_name, sc_input=sc_input,
+        analysis=analysis, macro_model=macro_model, ap_flag=ap_flag)
 
     
 #-----------------------------------------------------------
     print(sc_input)
-    sgDehomoData_name=SCfileName
+    sgDehomoData_name = SCfileName
     sc_global = sc_input + r'.glb'
-    sc_input_sc=os.path.basename(sc_input)
+    sc_input_sc = os.path.basename(sc_input)
     # Check if there is a odb file with the destination name have already exist:
     checkDehoVisual(sc_input_sc, 'Dehomo')
 
 
     
-    sgDehomoData=mdb.customData.SgDehomoData(name=sgDehomoData_name)
-    sgDehomoData.createSgDehomoData(debug, sgmodel_source, sg_name,sc_input,analysis,macro_model,
-                    macro_displacement=tuple(v), macro_roatation=tuple(c), beam_strain=tuple(be), shell_strain=tuple(se),solid_strain=tuple(e), tm=tm)
+    sgDehomoData = mdb.customData.SgDehomoData(name=sgDehomoData_name)
+    sgDehomoData.createSgDehomoData(
+        debug, sgmodel_source, sg_name, sc_input, analysis, macro_model,
+        macro_displacement=tuple(v), macro_roatation=tuple(c),
+        beam_strain=tuple(be), shell_strain=tuple(se), solid_strain=tuple(e), tm=tm,
+        beam_model=beam_model)
     if info==1:
         print(('---> Create sgDehomoData: %s' % sg_name))
         print(('    mdb.customData.sgDehomoDataSets[\'%s\']' % sgDehomoData_name))
@@ -100,13 +119,18 @@ def localization(
         print('Macroscopic roatations')
         print(c)
         if macro_model_dimension=='1D':
-            print('beam macroscopic strain and curvatures :')
+            print('beam macroscopic strain and curvatures :' if load_measure==1 else 'beam generalized stress resultants :')
             print(be)
+            print('Beam model: %s' % beam_model)
         elif macro_model_dimension=='2D':
-            print('shell macroscopic strain and curvatures :')
+            print('shell macroscopic strain and curvatures :' if load_measure==1 else 'shell generalized stress resultants :')
             print(se)
+            print('Shell model: %s' % shell_model)
+            if shell_model.lower() in ('mindlin','reissner-mindlin','reissner–mindlin'):
+                print('Mindlin extra pair:')
+                print(mindlin_extra)
         elif macro_model_dimension=='3D':
-            print('3D solid macroscopic strain :')
+            print('3D solid macroscopic strain :' if load_measure==1 else '3D solid macroscopic stress :')
             print(e)
 
 
@@ -122,12 +146,28 @@ def localization(
         fout.write('\n')
         writeFormat(fout, 'd', [load_measure])
         fout.write('\n')
+
+        # Write generalized quantities by dimensional model
         if macro_model_dimension == '1D':
+            # be contains [e11, k11, k12, k13] OR for stress [F1, M1, M2, M3] if user entered that order
             writeFormat(fout, 'E'*4, be)
+            # For Timoshenko we don't need to force placeholders; GUI provides correct triplets in 'be'
+            # and 'bk', already folded above.
+
         elif macro_model_dimension == '2D':
+            # For KL: 6 numbers. For Mindlin: 6 + 2 numbers (extra pair).
+            # 'se' already includes membrane (3) + bending (3) after folding se[0] + sk[0].
             writeFormat(fout, 'E'*6, se)
+            # If Mindlin/Reissner–Mindlin, append the extra 2 values.
+            if len(mindlin_extra) > 0:
+                pair = (mindlin_extra + [0.0, 0.0])[:2]
+                fout.write('\n')
+                writeFormat(fout, 'E'*2, pair)
+
         elif macro_model_dimension == '3D':
+            # 6 numbers for 3D (strain or stress), already folded into 'e'
             writeFormat(fout, 'E'*6, e)
+
         fout.write('\n')
         if analysis==1:
             writeFormat(fout, 'E', tm)
@@ -168,4 +208,3 @@ def localization(
     print('Odb file creation time: %s' % str(visualTime))
 
     return
-

--- a/scripts/py3/scVisualMain.py
+++ b/scripts/py3/scVisualMain.py
@@ -14,6 +14,7 @@ import utilities_abq as uab
 from textRepr import *
 from UcheckDehoVisual import *
 import os.path
+import os, shutil
 
 # ==============================================================================
 #
@@ -91,9 +92,11 @@ def visualization(macro_model, ap_flag, sc_input):
     elem_connt_s9 = []
     
     elem_connt_c4  = []
+    elem_connt_c6  = []
     elem_connt_c10 = []
     elem_connt_c8  = []
     elem_connt_c20 = []
+    elem_connt_c15 = []
     
     elem_connt_b31_temp=[]
     elem_connt_b31 = []
@@ -150,10 +153,14 @@ def visualization(macro_model, ap_flag, sc_input):
                     elif len(line) >= 22:       # 3D element
                         if len(temp) == 5:
                             elem_connt_c4.append(tuple(temp))
+                        elif len(temp) == 7:   
+                            elem_connt_c6.append(tuple(temp))
                         elif len(temp) == 11:
                             elem_connt_c10.append(tuple(temp))
                         elif len(temp) == 9:
                             elem_connt_c8.append(tuple(temp))
+                        elif len(temp) == 16:  
+                            elem_connt_c15.append(tuple(temp))
                         elif len(temp) == 21:
                             elem_connt_c20.append(tuple(temp))
                     sect = line[1]                  # Read material sections
@@ -167,8 +174,10 @@ def visualization(macro_model, ap_flag, sc_input):
     elem_connt_s4.sort()
     elem_connt_s8.sort()
     elem_connt_c4.sort()
+    elem_connt_c6.sort()
     elem_connt_c10.sort()
     elem_connt_c8.sort()
+    elem_connt_c15.sort() 
     elem_connt_c20.sort()
     
     # 1D 
@@ -363,6 +372,27 @@ def visualization(macro_model, ap_flag, sc_input):
     odb_title = project_name
     odb_file_name = os.path.join(project_path, project_name + '.odb')
 
+    # Check if ODB already exists
+    if os.path.exists(odb_file_name):
+        print("--! Warning: ODB file already exists and will be overwritten.")
+        try:
+            # Try closing if it's open
+            try:
+                odb = openOdb(odb_file_name)
+                odb.close()
+            except:
+                pass
+
+            os.remove(odb_file_name)
+            aux_dir = odb_file_name + "_f"
+            if os.path.isdir(aux_dir):
+                shutil.rmtree(aux_dir)
+
+            print("--> Existing ODB deleted.")
+        except OSError as e:
+            print("--! Failed to delete existing ODB: {}".format(e))
+            sys.exit(1)
+    
     odb = Odb(name = odb_name, 
               analysisTitle = odb_title, 
               description = 'SwiftComp Dehomogenization', 
@@ -379,10 +409,15 @@ def visualization(macro_model, ap_flag, sc_input):
                         u_data, sg_strain, sg_stress, sn_strain, sn_stress, 
                         sgm_strain, sgm_stress, snm_strain, snm_stress)
     elif nsg == 3:
-        visualization3D(odb, project_name, node_coord, elem_connt_c4, elem_connt_c10, 
-                        elem_connt_c8, elem_connt_c20, elem_sectn, node_label, elem_label, 
-                        u_data, sg_strain, sg_stress, sn_strain, sn_stress, 
-                        sgm_strain, sgm_stress, snm_strain, snm_stress)
+        visualization3D(odb, project_name, node_coord,
+                        elem_connt_c4, elem_connt_c6,
+                        elem_connt_c8, elem_connt_c10,
+                        elem_connt_c15, elem_connt_c20,
+                        elem_sectn, node_label, elem_label,
+                        u_data, sg_strain, sg_stress,
+                        sn_strain, sn_stress,
+                        sgm_strain, sgm_stress,
+                        snm_strain, snm_stress)
     elif nsg == 1:
         visualization1D(odb, project_name, node_coord, elem_connt_b31, elem_sectn, node_label, elem_label, 
                         u_data, sg_strain, sg_stress, sn_strain, sn_stress)
@@ -910,9 +945,10 @@ def visualization2D(
 #
 # ==============================================================================
 
-def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt_c10, 
-                    elem_connt_c8, elem_connt_c20, elem_sectn, node_label, elem_label, 
-                    u_data, sg_strain, sg_stress, sn_strain, sn_stress, 
+def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt_c6,
+                    elem_connt_c8, elem_connt_c10, elem_connt_c15, elem_connt_c20,
+                    elem_sectn, node_label, elem_label,
+                    u_data, sg_strain, sg_stress, sn_strain, sn_stress,
                     sgm_strain, sgm_stress, snm_strain, snm_stress):
 
     # -----------------------
@@ -955,12 +991,18 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
     if elem_connt_c4 != []:
         elem_connt_c4 = tuple(elem_connt_c4)
         part_1.addElements(elementData = elem_connt_c4, type = 'C3D4', elementSetName = 'eSet-c3d4')
+    if elem_connt_c6 != []:
+        elem_connt_c6 = tuple(elem_connt_c6)
+        part_1.addElements(elementData = elem_connt_c6, type = 'C3D6', elementSetName = 'eSet-c3d6')
     if elem_connt_c10 != []:
         elem_connt_c10 = tuple(elem_connt_c10)
         part_1.addElements(elementData = elem_connt_c10, type = 'C3D10', elementSetName = 'eSet-c3d10')
     if elem_connt_c8 != []:
         elem_connt_c8 = tuple(elem_connt_c8)
         part_1.addElements(elementData = elem_connt_c8, type = 'C3D8', elementSetName = 'eSet-c3d8')
+    if elem_connt_c15 != []:
+        elem_connt_c15 = tuple(elem_connt_c15)
+        part_1.addElements(elementData = elem_connt_c15, type = 'C3D15', elementSetName = 'eSet-c3d15')
     if elem_connt_c20 != []:
         elem_connt_c20 = tuple(elem_connt_c20)
         part_1.addElements(elementData = elem_connt_c20, type = 'C3D20', elementSetName = 'eSet-c3d20')
@@ -1004,7 +1046,7 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
     
     # ---- GLOBAL COORDINATES ----
     print(' --> Importing strain and stress data under global coordinates...')
-    # Strains at integration points
+    """# Strains at integration points
     if sg_strain != []:
         print('  --> Strains at integration points...')
         s_field = frame_1.FieldOutput(
@@ -1038,7 +1080,7 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
             labels = elem_label, 
             data = sg_stress
             )
-        odb_vis.save()
+        odb_vis.save()"""
     
     # Strains at elemental nodes
     if sn_strain != []:
@@ -1079,7 +1121,7 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
     
     # ---- MATERIAL COORDINATES ----
     print(' --> Importing strain and stress data under material coordinates...')
-    # Strains at integration points
+    """# Strains at integration points
     if sgm_strain != []:
         print('  --> Strains at integration points...')
         s_field = frame_1.FieldOutput(
@@ -1113,7 +1155,7 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
             labels = elem_label, 
             data = sgm_stress
             )
-        odb_vis.save()
+        odb_vis.save()"""
     
     # Strains at elemental nodes
     if snm_strain != []:

--- a/scripts/py3/userDataSG.py
+++ b/scripts/py3/userDataSG.py
@@ -61,7 +61,10 @@ class SgDehomoData(CommandRegister):
     def createSgDehomoData(self, debug, sgmodel_source, sg_name, sc_input, 
                            analysis, macro_model, macro_displacement, 
                            macro_roatation, beam_strain, shell_strain, 
-                           solid_strain, tm=0.0):
+                           solid_strain, tm=0.0,
+                           load_measure=1,
+                           beam_model="Euler",
+                           shell_model="Kirchhoff"):
         
         if sgmodel_source == 1:
             self.sgmodel_source = 'fromSGmodel'
@@ -92,15 +95,18 @@ class SgDehomoData(CommandRegister):
             self.macro_model_dimension = str(macro_model) + 'D'
             self.analysis              = analysis
             
-        self.macro_displacement = macro_displacement #RegisteredTuple(macro_displacement)
-        self.macro_roatation    = macro_roatation #RegisteredTuple(macro_roatation)
+        self.macro_displacement = macro_displacement # RegisteredTuple(macro_displacement)
+        self.macro_roatation    = macro_roatation    # RegisteredTuple(macro_roatation)
+        self.load_measure       = load_measure       # 0: stress, 1: strain
         macro_model_dimension   = self.macro_model_dimension
         if macro_model_dimension == '1D':
-            self.macro_strain = beam_strain #RegisteredTuple(beam_strain)
+            self.macro_strain = beam_strain          # RegisteredTuple(beam_strain) or stress resultants slots
+            self.beam_model   = beam_model
         elif macro_model_dimension == '2D':
-            self.macro_strain = shell_strain #RegisteredTuple(shell_strain)
+            self.macro_strain = shell_strain         # RegisteredTuple(shell_strain) or stress resultants slots
+            self.shell_model  = shell_model
         elif macro_model_dimension == '3D':
-            self.macro_strain = solid_strain #RegisteredTuple(solid_strain)
+            self.macro_strain = solid_strain         # RegisteredTuple(solid_strain) or stress components
         
         if self.analysis == 1:
             self.temperature_increment = tm
@@ -109,4 +115,3 @@ class SgDehomoData(CommandRegister):
     
 mdb.customData.Repository('sgs', Sg)
 mdb.customData.Repository('sgDehomoDataSets', SgDehomoData)            
-        


### PR DESCRIPTION
New features

Dehomogenization

1) CAE mode has Strain/Stress switching

The “Generalized strain/stress” dropdown in CAE mode actively switches the input tables (1D/2D/3D layouts update the table inputs instantly).

2) Automatic model detection for SGs for CAE

The dialog auto-detects the macroscopic model from the selected SG:

1D (Beam): Euler vs Timoshenko.

2D (Shell): Kirchhoff vs Mindlin.

3D (Solid): no model required.

3) Clear error when SG data is missing

If a CAE SG lacks the information needed to determine the model (e.g., Euler vs Timoshenko), the dialog shows one informative error explaining the fix.

4) Added generalized-input tables based on the SwiftComp manual

1D Euler tables show ε11 alone (or F1 for stress) plus the correct curvature/moment triplet.

1D Timoshenko shows ε11, γ12, γ13 (or F1, F2, F3) with the correct curvature/moment triplet.

2D Kirchhoff and 2D Mindlin layouts are distinct; Mindlin includes the extra 2.

3D layouts show the expected normal + shear sets for strain or stress.

5) Beam/Shell selectors shown only when needed

In SC mode:

1D → shows Beam model selector (Euler/Timoshenko).

2D → shows Shell model selector (Kirchhoff/Mindlin).

3D → hides both.

In CAE mode: these selectors are hidden (the model type is auto-detected).

6) Responsive and scrollable dialog

The window is resizable and includes a vertical scrollbar, so OK/Cancel stay visible regardless of screen size or content height.

7) UI refresh

The dialog recalculates and relayouts views after changes (source switch, model switch, measure switch), ensuring the visible tables always match the current selection.

Visualization

1) Overwrite ODB file when the file already exists

Overwrite existing ODB file instead of throwing an error when the user runs dehomogenization twice, otherwise the user will need to close Abaqus and delete the ODB file manually and then reopen Abaqus, which is inconvenient.

2) Support C3D6 and C3D15 element type

Added relevant logics for C3D6 and C3D15 wedge elements, which prevents the script from throwing an error when the elements contain wedge elements.

3) Disabled writing integration point data

Because there is a mismatch between integration point data from SwiftComp output files and the expected data for the ODB file (SwiftComp output files provide less data for integration points), the logics for writing integration point data to the ODB file has been commented out. The integration point data is not typically used thus it is safe to comment out.