### PR TITLE
Update homogenization and bug fixes for dehomogenization

### DIFF
--- a/scripts/py3/UdetermineNSG.py
+++ b/scripts/py3/UdetermineNSG.py
@@ -17,27 +17,26 @@ def determineNSG(model_name, part_name):
     eflag_2D = 0
     eflag_1D = 0
     
-    if meshStats.numHexElems > 0 or meshStats.numTetBoundaryElems > 0 or meshStats.numTetElems > 0:
+    if meshStats.numHexElems > 0 or meshStats.numTetBoundaryElems > 0 or meshStats.numTetElems > 0 or meshStats.numWedgeElems > 0:
         eflag_3D = 1
 #        print '3D nSG'
-    elif meshStats.numWedgeElems > 0:
-        raise ValueError('part[%s] contains wedge elements, which is not supported in SwiftComp.' % part_name )
     elif meshStats.numTriElems > 0 or meshStats.numQuadElems> 0:
         eflag_2D = 1
 #        print '2D nSG'
     elif meshStats.numLineElems > 0:
         eflag_1D = 1
 #        print '1D nSG'
-    t = eflag_3D * eflag_2D * eflag_1D
-    if t != 0:
-        raise ValueError('part[%s] contains elements of the different dimensions, please delete the unwanted elements.' % part_name )
-    elif t == 0:
-        if eflag_3D == 1:
-            nSG = 3
-        elif eflag_2D == 1:
-            nSG = 2
-        elif eflag_1D == 1:
-            nSG = 1
-    
+    t = eflag_3D + eflag_2D + eflag_1D
+    if t > 1:
+        raise ValueError('part[%s] contains elements of different dimensions; please delete the unwanted elements.' % part_name)
+    if t == 0:
+        raise ValueError('part[%s] has no supported elements.' % part_name)
+
+    if eflag_3D:
+        nSG = 3
+    elif eflag_2D:
+        nSG = 2
+    else:
+        nSG = 1
+
     return nSG
-    

--- a/scripts/py3/Usgmodel_info.py
+++ b/scripts/py3/Usgmodel_info.py
@@ -7,6 +7,40 @@ from utilities import *
 import os
 from userDataSG import *
 
+def _get_sc_dim_sub(sc_path):
+    import re
+    def _noncomment_lines(path):
+        with open(path, 'r') as f:
+            for line in f:
+                s=line.strip()
+                if s and not s.startswith('#'):
+                    yield s
+    lines=list(_noncomment_lines(sc_path))
+    if not lines:
+        return ("3D","Solid")
+    def _is_int(t):
+        try: int(t); return True
+        except: return False
+    toks=re.split(r'\s+', lines[0])
+    if not toks or not _is_int(toks[0]) or int(toks[0]) not in (0,1,2,3):
+        return ("3D","Solid")
+    mflag=int(toks[0])
+    def _count_reals(s):
+        try:
+            return len([x for x in re.split(r'\s+', s) if x and (x=='0' or x=='0.0' or float(x)==float(x))])
+        except:
+            return 0
+    n2=_count_reals(lines[1]) if len(lines)>1 else 0
+    n3=_count_reals(lines[2]) if len(lines)>2 else 0
+    if n2==3 and n3>=2:
+        dim="1D"
+        sub={0:"Euler",1:"Timoshenko",2:"Vlasov",3:"Trapeze"}.get(mflag,"Unknown")
+    elif n2==2:
+        dim="2D"
+        sub={0:"Kirchhoff",1:"Mindlin"}.get(mflag,"Unknown")
+    else:
+        dim,sub="3D","Solid"
+    return (dim, sub)
 
 def sgmodel_info(sgmodel_source, sg_name, sc_input,  analysis, macro_model, ap_flag):
 
@@ -61,5 +95,5 @@ def sgmodel_info(sgmodel_source, sg_name, sc_input,  analysis, macro_model, ap_f
         macro_model_dimension = str(macro_model) + 'D'
         
     
-    
-    return SCfileName, sc_input, analysis, macro_model, macro_model_dimension, ap_flag
+    sc_dim, sc_sub = _get_sc_dim_sub(sc_input)
+    return SCfileName, sc_input, analysis, macro_model, macro_model_dimension, ap_flag, sc_dim, sc_sub

--- a/scripts/py3/createSCInputMain.py
+++ b/scripts/py3/createSCInputMain.py
@@ -38,7 +38,7 @@ def createSCInputMain(
     results = reorgAbaqusInput(
         nsg, nodes, elements2d, elements3d, elsets,
         sections, distributions, orientations,
-        materials, densities, elastics
+        materials, densities, elastics, trans_flag
     )
     n_coord = results['nodes']
     eid_all = results['all elements ids']

--- a/scripts/py3/createVABSInputMain.py
+++ b/scripts/py3/createVABSInputMain.py
@@ -38,7 +38,7 @@ def createVABSInputMain(
     results = reorgAbaqusInput(
         nsg, nodes, elements2d, elements3d, elsets,
         sections, distributions, orientations,
-        materials, densities, elastics
+        materials, densities, elastics, trans_flag
     )
     n_coord = results['nodes']
     eid_all = results['all elements ids']

--- a/scripts/py3/parseAbaqusInput.py
+++ b/scripts/py3/parseAbaqusInput.py
@@ -1,76 +1,105 @@
 import sys
-import numpy as np
 import inpParser
 
 def parseAbaqusInput(abq_inp_name):
+    def to_list(x):
+        try: return x.tolist()
+        except Exception: return list(x)
+
+    def nodes_from_kwdata(data):
+        out = []
+        if data is None: return out
+        for row in to_list(data):
+            r = to_list(row)
+            if not r: continue
+            # id
+            i0 = None
+            for v in r:
+                if v is None: continue
+                try:
+                    i0 = int(v); break
+                except Exception:
+                    pass
+            if i0 is None: continue
+            # xyz
+            coords = []
+            for v in r[1:]:
+                if v is None: continue
+                try: coords.append(float(v))
+                except Exception: pass
+            while len(coords) < 3:
+                coords.append(0.0)
+            out.append([i0] + coords[:3])
+        return out
+
+    def collect_elements_fixed_width(data, width):
+        if data is None: return []
+        toks = []
+        for row in to_list(data):
+            for v in to_list(row):
+                if v is None: continue
+                try:
+                    toks.append(int(v))
+                except Exception:
+                    pass
+        rows, i = [], 0
+        while i + width <= len(toks):
+            rows.append(toks[i:i+width])
+            i += width
+        return rows
 
     inp = inpParser.InputFile(abq_inp_name)
     kws_obj = inp.parse(usePyArray=True)
 
-    el_2d3_type = ['S3', 'S3R']
-    el_2d4_type = ['S4', 'S4R']
-    el_2d6_type = ['STRI65',]
-    el_2d8_type = ['S8R',]
-    el_3d4_type = []
-    el_3d8_type = ['C3D8', 'C3D8R',]
-    el_3d10_type = ['C3D10',]
-    el_3d20_type = ['C3D20',]
+    # element families
+    el_2d3_type  = {'S3','S3R'}
+    el_2d4_type  = {'S4','S4R'}
+    el_2d6_type  = {'STRI65'}
+    el_2d8_type  = {'S8R'}
+    el_3d4_type  = {'C3D4'}
+    el_3d6_type  = {'C3D6'}
+    el_3d8_type  = {'C3D8','C3D8R'}
+    el_3d10_type = {'C3D10'}
+    el_3d15_type = {'C3D15'}
+    el_3d20_type = {'C3D20','C3D20R'}
 
-    e_connt_2d3 = np.zeros((1, 4), dtype=int)
-    e_connt_2d4 = np.zeros((1, 5), dtype=int)
-    e_connt_2d6 = np.zeros((1, 7), dtype=int)
-    e_connt_2d8 = np.zeros((1, 9), dtype=int)
-    e_connt_3d4 = np.zeros((1, 5), dtype=int)
-    e_connt_3d8 = np.zeros((1, 9), dtype=int)
-    e_connt_3d10 = np.zeros((1, 11), dtype=int)
-    e_connt_3d20 = np.zeros((1, 21), dtype=int)
+    # expected widths (eid + nodes)
+    widths = {
+        '2d3':  1+3,  '2d4':  1+4,  '2d6':  1+6,  '2d8':  1+8,
+        '3d4':  1+4,  '3d6':  1+6,  '3d8':  1+8,  '3d10': 1+10,
+        '3d15': 1+15, '3d20': 1+20,
+    }
 
-    elsets_raw = []
-    distributions = []
-    orientations = []
-    sections = []
-    materials = []
-    densities = []
-    elastics = []
-
-    mtr_name2id = {}
-    lyt_name2id = {}
-
-    mid = 0
-    lid = 0
+    e_connt_2d3=e_connt_2d4=e_connt_2d6=e_connt_2d8=[]
+    e_connt_3d4=e_connt_3d6=e_connt_3d8=e_connt_3d10=e_connt_3d15=e_connt_3d20=[]
+    elsets_raw, distributions, orientations, sections = [], [], [], []
+    materials, densities, elastics = [], [], []
+    mtr_name2id, lyt_name2id = {}, {}
+    mid = lid = 0
     nsg = 3
+    n_coord = []
+
     for kw in kws_obj:
-        # print kw.name
         if kw.name == 'parameter':
-            # print kw.parameter
-            try:
-                nsg = kw.parameter['sgdim']
-            except KeyError:
-                nsg = 3
+            try: nsg = kw.parameter['sgdim']
+            except Exception: nsg = 3
+
         elif kw.name == 'node':
-            # print np.array(kw.data)[:,:4]
-            # print kw.data[0]
-            # n_coord = np.array(kw.data)[:,:4]
-            n_coord = kw.data
-            # print n_coord[0]
+            n_coord = nodes_from_kwdata(kw.data)
+
         elif kw.name == 'element':
             et = kw.parameter['type']
-            if et in el_2d3_type:
-                e_connt_2d3 = np.vstack((e_connt_2d3, kw.data))
-            elif et in el_2d4_type:
-                e_connt_2d4 = np.vstack((e_connt_2d4, kw.data))
-            elif et in el_2d6_type:
-                e_connt_2d6 = np.vstack((e_connt_2d6, kw.data))
-            elif et in el_2d8_type:
-                e_connt_2d8 = np.vstack((e_connt_2d8, kw.data))
-            elif et in el_3d4_type:
-                e_connt_3d4 = np.vstack((e_connt_3d4, kw.data))
-            elif et in el_3d8_type:
-                e_connt_3d8 = np.vstack((e_connt_3d8, kw.data))
-            elif et in el_3d10_type:
-                e_connt_3d10 = np.vstack((e_connt_3d10, kw.data))
-            elif et in el_3d20_type:
-                e_connt_3d20 = np.vstack((e_connt_3d20, kw.data))
+            if   et in el_2d3_type:   rows = collect_elements_fixed_width(kw.data, widths['2d3']);  e_connt_2d3  = e_connt_2d3  + rows
+            elif et in el_2d4_type:   rows = collect_elements_fixed_width(kw.data, widths['2d4']);  e_connt_2d4  = e_connt_2d4  + rows
+            elif et in el_2d6_type:   rows = collect_elements_fixed_width(kw.data, widths['2d6']);  e_connt_2d6  = e_connt_2d6  + rows
+            elif et in el_2d8_type:   rows = collect_elements_fixed_width(kw.data, widths['2d8']);  e_connt_2d8  = e_connt_2d8  + rows
+            elif et in el_3d4_type:   rows = collect_elements_fixed_width(kw.data, widths['3d4']);  e_connt_3d4  = e_connt_3d4  + rows
+            elif et in el_3d6_type:   rows = collect_elements_fixed_width(kw.data, widths['3d6']);  e_connt_3d6  = e_connt_3d6  + rows
+            elif et in el_3d8_type:   rows = collect_elements_fixed_width(kw.data, widths['3d8']);  e_connt_3d8  = e_connt_3d8  + rows
+            elif et in el_3d10_type:  rows = collect_elements_fixed_width(kw.data, widths['3d10']); e_connt_3d10 = e_connt_3d10 + rows
+            elif et in el_3d15_type:  rows = collect_elements_fixed_width(kw.data, widths['3d15']); e_connt_3d15 = e_connt_3d15 + rows
+            elif et in el_3d20_type:  rows = collect_elements_fixed_width(kw.data, widths['3d20']); e_connt_3d20 = e_connt_3d20 + rows
+
         elif kw.name == 'elset':
             elsets_raw.append(kw)
         elif kw.name == 'distribution':
@@ -93,22 +122,23 @@ def parseAbaqusInput(abq_inp_name):
             elastics.append(kw)
 
     e_connt_2d = {3:e_connt_2d3, 4:e_connt_2d4, 6:e_connt_2d6, 8:e_connt_2d8}
-    e_connt_3d = {4:e_connt_3d4, 8:e_connt_3d8, 10:e_connt_3d10, 20:e_connt_3d20}
+    e_connt_3d = {4:e_connt_3d4, 6:e_connt_3d6, 8:e_connt_3d8, 10:e_connt_3d10, 15:e_connt_3d15, 20:e_connt_3d20}
 
     elsets = {}
     for elset in elsets_raw:
-        elset_name = elset.parameter['elset']
-        # print elset.data
-        if 'generate' in list(elset.parameter.keys()):
-            [start, stop, step] = elset.data[0]
-            elsets[elset_name] = np.arange(start, stop+1, step)
+        name = elset.parameter['elset']
+        if 'generate' in elset.parameter:
+            start, stop, step = to_list(elset.data[0])
+            elsets[name] = list(range(int(start), int(stop)+1, int(step)))
         else:
-            temp1 = np.array(elset.data[:-1]).ravel()
-            temp2 = np.array(elset.data[-1])
-            elsets[elset_name] = np.hstack([temp1, temp2])
+            flat = []
+            for row in to_list(elset.data):
+                for v in to_list(row):
+                    if v is None: continue
+                    try: flat.append(int(v))
+                    except Exception: pass
+            elsets[name] = flat
 
-    # print elsets
-    # print n_coord[0]
     return {
         'nsg': nsg,
         'nodes': n_coord,
@@ -121,28 +151,4 @@ def parseAbaqusInput(abq_inp_name):
         'materials': materials,
         'densities': densities,
         'elastics': elastics
-        }
-
-# ====================================================================
-# Structures of Outputs
-# -------------------------
-# n_coord: array([
-#              [id1 x1 y1 z1]
-#              [id2 x2 y2 z2]
-#              ...
-#          ])
-# e_connt: array([
-#              [id1 n11 n12 n13 ...]
-#              [id2 n21 n22 n23 ...]
-#              ...
-#          ])
-# elsets: {'name1':array([e11, e12, e13, ...]),
-#          'name2':array([e21, e22, e23, ...]),
-#          ...
-#         }
-#
-# ====================================================================
-
-# abq_inp = r'airfoil_automation\test_1102.inp'
-# abq_inp = r'test.inp'
-# parseAbaqusInput(abq_inp)
+    }

--- a/scripts/py3/reorgAbaqusInput.py
+++ b/scripts/py3/reorgAbaqusInput.py
@@ -1,74 +1,81 @@
-import numpy as np
 import os
 
 def reorgAbaqusInput(
     nsg,
     nodes, elements2d, elements3d, elsets,
     sections, distributions, orientations,
-    materials, densities, elastics
+    materials, densities, elastics,
+    trans_flag
 ):
-
     material_type = {
         'ISOTROPIC': 0,
         'ENGINEERINGCONSTANTS': 1,
         'ORTHOTROPIC': 2,
         'ANISOTROPIC': 2
-        }
+    }
 
-    # ----- Nodal coordinates ----------------------------------------
-    # nid = nodes[:, 0]
-    # if nsg == 1:
-    #     n_coord = nodes[:, [3,]]
-    # elif nsg == 2:
-    #     n_coord = nodes[:, [2, 3]]
-    # elif nsg == 3:
-    #     n_coord = nodes[:, [1, 2, 3]]
+    def to_list(a):
+        try:
+            return a.tolist()
+        except Exception:
+            return list(a)
+
     n_coord = nodes
-    # print n_coord[0]
 
-    # ----- Materials ------------------------------------------------
     mtr_id = 0
     mtr = {}
     mtr_name2id = {}
-    nmate = len(materials)
-    for i in range(nmate):
-        mtr_name = materials[i].parameter['name']
+    for i in range(len(materials)):
+        mname_raw = str(materials[i].parameter.get('name', '')).strip()
+        if not mname_raw:
+            raise ValueError(f"material[{i}] has no name")
+        mname_key = mname_raw.upper()
         mtr_id += 1
-        mtr_name2id[mtr_name] = mtr_id
+        mtr_name2id[mname_key] = mtr_id
         try:
-            mtr_type = elastics[i].parameter['type']
+            mtr_type_str = elastics[i].parameter['type'] if i < len(elastics) and elastics[i] is not None else 'ISOTROPIC'
         except KeyError:
-            mtr_type = 'ISOTROPIC'
-        mtr_type = material_type[mtr_type]
+            mtr_type_str = 'ISOTROPIC'
+        mtr_type = material_type.get(str(mtr_type_str).upper(), 0)
         mtr[mtr_id] = {'isotropy': mtr_type, 'ntemp': 1, 'elastic': []}
-        try:
-            rho = densities[i].data[0][0]
-        except IndexError:
-            rho = 1.0
-        # print elastics[i].data
-        # els = np.array(elastics[i].data).ravel()
+
+        # Density
+        if i < len(densities) and densities[i] and densities[i].data:
+            try:
+                rho = float(densities[i].data[0][0])
+            except Exception as e:
+                raise ValueError(f"density parse failed for material '{mname_raw}': {e}")
+        else:
+            print(f"!! density missing for material '{mname_raw}', defaulting to 0.0")
+            rho = 0.0
+
+        # Elastic constants
         els = []
-        for j in elastics[i].data:
-            for k in j:
-                if k is not None:
-                    els.append(k)
-        # print els
+        if i < len(elastics) and elastics[i] and getattr(elastics[i], 'data', None):
+            for j in elastics[i].data:
+                for k in j:
+                    if k is not None:
+                        try:
+                            els.append(float(k))
+                        except Exception as e:
+                            raise ValueError(f"elastic constant '{k}' not numeric for '{mname_raw}': {e}")
+        else:
+            raise ValueError(f"elastic block missing for material '{mname_raw}'")
+
         if mtr_type == 0:
             elastic = els
         elif mtr_type == 1:
-            elastic = [
-                els[0], els[1], els[2],
-                els[6], els[7], els[8],
-                els[3], els[4], els[5]
-            ]
+            if len(els) < 9:
+                raise ValueError(f"ENGINEERINGCONSTANTS for '{mname_raw}' has {len(els)} values (<9)")
+            elastic = [els[0], els[1], els[2], els[6], els[7], els[8], els[3], els[4], els[5]]
         elif mtr_type == 2:
             if len(els) == 9:
                 elastic = [
-                    els[0], els[1], els[3],    0.0,    0.0,    0.0,
-                            els[2], els[4],    0.0,    0.0,    0.0,
-                                    els[5],    0.0,    0.0,    0.0,
-                                            els[8],    0.0,    0.0,
-                                                    els[7],    0.0,
+                    els[0], els[1], els[3], 0.0, 0.0, 0.0,
+                            els[2], els[4], 0.0, 0.0, 0.0,
+                                    els[5], 0.0, 0.0, 0.0,
+                                            els[8], 0.0, 0.0,
+                                                    els[7], 0.0,
                                                             els[6]
                 ]
             elif len(els) == 21:
@@ -80,142 +87,328 @@ def reorgAbaqusInput(
                                                      els[14], els[13],
                                                               els[9]
                 ]
-        elastic = np.hstack(([20.0, rho], elastic))
-        # print elastic
-        mtr[mtr_id]['elastic'].append(elastic)
+            else:
+                raise ValueError(f"ORTHO/ANISO for '{mname_raw}' has unexpected length {len(els)} (expected 9 or 21)")
+        else:
+            elastic = els
+        mtr[mtr_id]['elastic'].append([0.0, rho] + list(elastic))
 
-    # ----- Layer types ----------------------------------------------
-    lid = 0
-    lyt = []
-    lyt_name2id = {}
-    used_lyt = []
-    used_elset = []
-    for s in sections:
-        lname = s.parameter['elset']
-        # used_elset.append(lname)
-        mname = s.parameter['material']
-        mid = mtr_name2id[mname]
-        mname_angle = lname.split('/')[0]
-        if mname_angle not in used_lyt:
-            lid += 1
-            lyt_name2id[mname_angle] = lid
-            i = mname_angle.rfind('_')
-            angle = mname_angle[i+1:]
-            if 'p' in angle:
-                angle = angle[1:]
-            elif 'n' in angle:
-                angle = angle.replace('n', '-')
-            angle = float(angle.replace('D', '.'))
-            lyt.append([lid, mid, angle])
-        used_lyt.append(mname_angle)
-        used_elset.append([lname, lyt_name2id[mname_angle]])
+    # Orientations
+    ori_deg = {}
+    for o in orientations:
+        name = o.parameter.get('name', '')
+        ang = 0.0
+        if getattr(o, 'data', None):
+            done = False
+            for row in o.data:
+                for v in row:
+                    try:
+                        ang = float(v)
+                        done = True
+                        break
+                    except Exception:
+                        pass
+                if done:
+                    break
+        ori_deg[name] = ang
 
-    # ----- Element connectivities -----------------------------------
+    # Distributions
+    dist_by_name = {}
+    for d in distributions:
+        dname = d.parameter.get('name', '')
+        if getattr(d, 'data', None):
+            rows = d.data[1:] if len(d.data) else []
+            if rows:
+                maxlen = max(len(r) for r in rows)
+                padded = []
+                for r in rows:
+                    rr = [x for x in r if x is not None]
+                    rr = rr + [0.0] * (maxlen - len(rr))
+                    try:
+                        rr = [float(x) for x in rr]
+                    except Exception as e:
+                        raise ValueError(f"distribution '{dname}' row parse failed: {r} ({e})")
+                    if rr:
+                        padded.append(rr)
+                arr = padded
+            else:
+                arr = []
+        else:
+            arr = []
+        dist_by_name[dname] = arr
+
     eid_lid = {}
-    for elset_lid in used_elset:
-        es = elsets[elset_lid[0]]
-        lid = elset_lid[1]
-        for e in es:
-            eid_lid[e] = lid
+    lyt = []
+    lid_map = {}
+    def get_lid(mid, angle):
+        key = (mid, float(angle))
+        if key not in lid_map:
+            lid = len(lid_map) + 1
+            lid_map[key] = lid
+            lyt.append([lid, mid, float(angle)])
+        return lid_map[key]
 
-    e_connt_2d3 = elements2d[3]
-    e_connt_2d4 = elements2d[4]
-    e_connt_2d6 = elements2d[6]
-    e_connt_2d8 = elements2d[8]
+    def _elem_angle_for(name, eid, base):
+        arr = dist_by_name.get(name, [])
+        if arr:
+            for row in arr:
+                try:
+                    if int(row[0]) == int(eid):
+                        return base + float(row[-1])
+                except Exception:
+                    continue
+        return base
 
-    e_connt_3d4 = elements3d[4]
-    e_connt_3d8 = elements3d[8]
-    e_connt_3d10 = elements3d[10]
-    e_connt_3d20 = elements3d[20]
+    # elements that have no composite/orientation but need identity transform
+    plain_eids = set()
+
+    for s in sections:
+        elset_key = s.parameter['elset']
+        if elset_key not in elsets:
+            raise ValueError(f"section refers to missing elset '{elset_key}'")
+
+        es   = elsets[elset_key]
+        onam = s.parameter.get('orientation', '')
+        base = ori_deg.get(onam, 0.0)
+        params = {k.lower(): v for k, v in s.parameter.items()}
+
+        if trans_flag == 0:
+            if ('composite' in params) or ('orientation' in params):
+                raise ValueError("Composite layup or orientation detected but elemental orientation is Global. Please set elemental orientation to Local.")
+            mraw = str(s.parameter.get('material', '')).strip()
+            mkey = mraw.upper()
+            if   mkey in mtr_name2id: mid = mtr_name2id[mkey]
+            elif mraw in mtr_name2id: mid = mtr_name2id[mraw]
+            else:
+                raise ValueError(f"section material not found: '{mraw}'")
+            for e in es:
+                eid_lid[int(e)] = mid
+
+        else:
+            if 'composite' in params:
+                rows = getattr(s, 'data', []) or []
+                ply_row = None
+                for r in rows:
+                    rr = [x for x in r if x is not None]
+                    if len(rr) >= 4:
+                        ply_row = rr
+                        break
+                if ply_row is None:
+                    raise ValueError(f"no usable ply row found in composite section '{elset_key}'")
+
+                mat_raw = str(ply_row[2]).strip()
+                mat_key = mat_raw.upper()
+                if   mat_key in mtr_name2id: mid = mtr_name2id[mat_key]
+                elif mat_raw in mtr_name2id: mid = mtr_name2id[mat_raw]
+                else:
+                    raise ValueError(f"composite ply material not found: raw='{mat_raw}' upper='{mat_key}' available={sorted(mtr_name2id.keys())}")
+
+                try:
+                    ang = float(ply_row[3])
+                except Exception as e:
+                    raise ValueError(f"composite ply angle not found or not numeric in section '{elset_key}': {e}")
+
+                lid = get_lid(mid, ang)
+                for e in es:
+                    eid_lid[int(e)] = lid
+
+            elif 'orientation' in params:
+                raise ValueError(f"Orientations are currently not supported by SwiftComp. Please use Composite Layups to define orientations.")
+
+            else:
+                mraw = str(s.parameter.get('material', '')).strip()
+                mkey = mraw.upper()
+                if   mkey in mtr_name2id: mid = mtr_name2id[mkey]
+                elif mraw in mtr_name2id: mid = mtr_name2id[mraw]
+                else:
+                    raise ValueError(f"section material not found: '{mraw}'")
+                lid = get_lid(mid, 0.0)
+                for e in es:
+                    eid = int(e)
+                    eid_lid[eid] = lid
+                    plain_eids.add(eid)
+
+    def rows_from_block(block):
+        out = []
+        if block is None:
+            return out
+        try:
+            block = to_list(block)
+        except Exception:
+            block = list(block)
+        for row in block:
+            r = to_list(row)
+            try:
+                r = [int(x) for x in r if x is not None]
+            except Exception as e:
+                raise ValueError(f"element row parse failed: {row} ({e})")
+            if r:
+                out.append(r)
+        return out
+
+    e_connt_2d3  = rows_from_block(elements2d.get(3, []))
+    e_connt_2d4  = rows_from_block(elements2d.get(4, []))
+    e_connt_2d6  = rows_from_block(elements2d.get(6, []))
+    e_connt__2d8 = rows_from_block(elements2d.get(8, []))
+
+    e_connt_3d4  = rows_from_block(elements3d.get(4, []))
+    e_connt_3d6  = rows_from_block(elements3d.get(6, []))
+    e_connt_3d8  = rows_from_block(elements3d.get(8, []))
+    e_connt_3d10 = rows_from_block(elements3d.get(10, []))
+    e_connt_3d15 = rows_from_block(elements3d.get(15, []))
+    e_connt_3d20 = rows_from_block(elements3d.get(20, []))
+
+    def drop_zero_eid(rows):
+        return [r for r in rows if len(r) > 0 and int(r[0]) != 0]
+
+    e_connt_2d3  = drop_zero_eid(e_connt_2d3)
+    e_connt_2d4  = drop_zero_eid(e_connt_2d4)
+    e_connt_2d6  = drop_zero_eid(e_connt_2d6)
+    e_connt_2d8  = drop_zero_eid(e_connt__2d8)
+    e_connt_3d4  = drop_zero_eid(e_connt_3d4)
+    e_connt_3d6  = drop_zero_eid(e_connt_3d6)
+    e_connt_3d8  = drop_zero_eid(e_connt_3d8)
+    e_connt_3d10 = drop_zero_eid(e_connt_3d10)
+    e_connt_3d15 = drop_zero_eid(e_connt_3d15)
+    e_connt_3d20 = drop_zero_eid(e_connt_3d20)
+
+    def pad2d(rows):
+        out = []
+        for r in rows:
+            rr = r + [0] * (9 - len(r))
+            out.append(rr[:9])
+        return out
+
+    def pad3d(rows):
+        out = []
+        for r in rows:
+            rr = r + [0] * (21 - len(r))
+            out.append(rr[:21])
+        return out
 
     e2d = []
-    if len(e_connt_2d3) > 1:
-        e_connt_2d3 = e_connt_2d3[1:]
-        z = np.zeros((len(e_connt_2d3), 6))
-        e_connt_2d3 = np.hstack([e_connt_2d3, z])
-        e2d.append(e_connt_2d3)
-    if len(e_connt_2d4) > 1:
-        e_connt_2d4 = e_connt_2d4[1:]
-        z = np.zeros((len(e_connt_2d4), 5))
-        e_connt_2d4 = np.hstack([e_connt_2d4, z])
-        e2d.append(e_connt_2d4)
-    if len(e_connt_2d6) > 1:
-        e_connt_2d6 = e_connt_2d6[1:]
-        z = np.zeros((len(e_connt_2d6), 2))
-        e_connt_2d6 = np.hstack([e_connt_2d6, z])
-        e_connt_2d6 = np.insert(e_connt_2d6, 4, 0, axis=1)
-        e2d.append(e_connt_2d6)
-    if len(e_connt_2d8) > 1:
-        e_connt_2d8 = e_connt_2d8[1:]
-        z = np.zeros((len(e_connt_2d8), 1))
-        e_connt_2d8 = np.hstack([e_connt_2d8, z])
-        e2d.append(e_connt_2d8)
-    if len(e2d) > 0:
-        elements2d = np.vstack(e2d)
-        elements2d = elements2d.astype(int)
-    else:
-        elements2d = []
+    if e_connt_2d3:
+        e2d += pad2d(e_connt_2d3)
+    if e_connt_2d4:
+        e2d += pad2d(e_connt_2d4)
+    if e_connt_2d6:
+        ins = []
+        for r in e_connt_2d6:
+            rr = r[:4] + [0] + r[4:]
+            ins.append(rr)
+        e2d += pad2d(ins)
+    if e_connt__2d8:
+        e2d += pad2d(e_connt__2d8)
+    elements2d_list = e2d
 
     e3d = []
-    if len(e_connt_3d4) > 1:
-        e_connt_3d4 = e_connt_3d4[1:]
-        z = np.zeros((len(e_connt_3d4), 16))
-        e_connt_3d4 = np.hstack([e_connt_3d4, z])
-        e3d.append(e_connt_3d4)
-    if len(e_connt_3d8) > 1:
-        e_connt_3d8 = e_connt_3d8[1:]
-        z = np.zeros((len(e_connt_3d8), 12))
-        e_connt_3d8 = np.hstack([e_connt_3d8, z])
-        e3d.append(e_connt_3d8)
-    if len(e_connt_3d10) > 1:
-        e_connt_3d10 = e_connt_3d10[1:]
-        z = np.zeros((len(e_connt_3d10), 9))
-        e_connt_3d10 = np.hstack([e_connt_3d10, z])
-        e_connt_3d10 = np.insert(e_connt_3d10, 5, 0, axis=1)
-        e3d.append(e_connt_3d10)
-    if len(e_connt_3d20) > 1:
-        e3d.append(e_connt_3d20)
-    if len(e3d) > 0:
-        elements3d = np.vstack(e3d)
-        elements3d = elements3d.astype(int)
-    else:
-        elements3d = []
-    nelem = len(elements2d) + len(elements3d)
-    # print nelem
+    if e_connt_3d4:
+        e3d += pad3d(e_connt_3d4)
+    if e_connt_3d8:
+        e3d += pad3d(e_connt_3d8)
+    if e_connt_3d10:
+        ins = []
+        for r in e_connt_3d10:
+            rr = r[:6] + [0] + r[6:]
+            ins.append(rr)
+        e3d += pad3d(ins)
+    if e_connt_3d20:
+        e3d += pad3d(e_connt_3d20)
+    if e_connt_3d6:
+        e3d += pad3d(e_connt_3d6)
+    if e_connt_3d15:
+        ins = []
+        for r in e_connt_3d15:
+            eid   = [r[0]]
+            nodes = r[1:16]
+            order = [0,1,2, 3,4,5, 6,7,8, 9,10,11, 12,13,14]
+            nodes = [nodes[i] for i in order]
+            keep  = eid + nodes
+            keep  = keep[:7] + [0] + keep[7:]
+            ins.append(keep)
+        e3d += pad3d(ins)
+    elements3d_list = e3d
 
-    # ----- Local coordinates ----------------------------------------
-    eid_all = np.arange(1, nelem+1).tolist()
+    # count elements
+    nelem = len(elements2d_list) + len(elements3d_list)
+
+    # renumber element labels to be contiguous starting at 1
+    blocks = [elements2d_list, elements3d_list]
+    new_id = 1
+    id_map = {}
+    for blk in blocks:
+        for r in blk:
+            old = int(r[0])
+            if old not in id_map:
+                id_map[old] = new_id
+                new_id += 1
+            r[0] = id_map[old]
+
+    # update mappings that depend on element id
+    eid_lid = {id_map[e]: lid for e, lid in eid_lid.items() if e in id_map}
+
+    # build distributions (and add identities for material-only elements if needed)
     distr_all = []
-    if len(distributions) > 0:
-        # Join all distributions
-        distr_all = np.zeros((1, 7))
-        for distr in distributions:
-            distr_all = np.vstack([distr_all, distr.data[1:]])
-        distr_all = distr_all[1:]
-        # print distr_all
-        # Extract element ids
-        eids = distr_all[:, 0]
-        # print eids
-        # Find indices of unique ids
-        eids_uni, eids_uni_i = np.unique(eids, return_index=True)
-        distr_uni = distr_all[eids_uni_i, :]
-        if nsg == 2:
-            distr_uni = distr_uni[:, :4]
-            distr_uni = np.insert(distr_uni, 1, 1, axis=1)
-            distr_uni = np.insert(distr_uni, 2, 0, axis=1)
-            distr_uni = np.insert(distr_uni, 3, 0, axis=1)
-        c_zeros = np.zeros((len(distr_uni), 3))
-        distr_all = np.hstack([distr_uni, c_zeros])
+    need_cols = 7 if int(nsg) == 3 else 4
+    rows = []
+    for distr in distributions:
+        if getattr(distr, 'data', None):
+            for row in distr.data[1:]:
+                flat = []
+                for v in row:
+                    if v is None:
+                        continue
+                    try:
+                        flat.append(float(v))
+                    except Exception as e:
+                        raise ValueError(f"distribution value '{v}' not numeric: {e}")
+                if not flat:
+                    continue
+                eid = int(flat[0])
+                rest = (flat[1:] + [0.0] * (need_cols - 1))[:need_cols - 1]
+                rows.append([eid] + rest)
+
+    # ensure identity transforms for elements without composite/orientation
+    if trans_flag != 0 and plain_eids:
+        have = {int(r[0]) for r in rows}
+        missing = sorted(e for e in plain_eids if e not in have)
+        if int(nsg) == 3:
+            rows.extend([[float(e), 1.0, 0.0, 0.0, 0.0, 1.0, 0.0] for e in missing])
+        else:
+            rows.extend([[float(e), 0.0, 1.0, 0.0] for e in missing])
+
+    if rows:
+        seen = set()
+        dedup = []
+        for r in rows:
+            if r[0] not in seen:
+                seen.add(r[0])
+                dedup.append(r)
+        if int(nsg) == 2:
+            out = []
+            for r in dedup:
+                r2 = r[:1] + [1.0, 0.0, 0.0] + r[1:]
+                out.append(r2)
+            dedup = out
+        for i in range(len(dedup)):
+            dedup[i] = dedup[i] + [0.0, 0.0, 0.0]
+        # apply renumber mapping for distributions
+        for r in dedup:
+            e_old = int(r[0])
+            if e_old in id_map:
+                r[0] = id_map[e_old]
+        distr_all = dedup
+
+    # rebuild all element ids
+    eid_all = list(range(1, nelem + 1))
 
     return {
-        # 'node ids': nid,
         'nodes': n_coord,
         'all elements ids': eid_all,
         'element to layer type': eid_lid,
-        'elements 2d': elements2d,
-        'elements 3d': elements3d,
+        'elements 2d': elements2d_list,
+        'elements 3d': elements3d_list,
         'distributions': distr_all,
         'layer types': lyt,
         'materials': mtr
     }
-

--- a/scripts/py3/scGenInput.py
+++ b/scripts/py3/scGenInput.py
@@ -18,6 +18,7 @@ from visualization import *
 from connectorBehavior import *
 import os
 import time
+import math
 from utilities import *
 from UwriteMaterials import *
 from userDataSG import *
@@ -32,20 +33,37 @@ def generateInputFromCAE(model_source, macro_model_dimension, analysis, elem_fla
 
     model    = mdb.models[model_name]
     part     = model.parts[part_name]
-    nodes    = part.nodes    
+    nodes    = part.nodes
     elements = part.elements
-    
+
+    # reject composite/elemental orientations in CAE path
+    has_comp = False
+    try:
+        for _nm,_ly in part.compositeLayups.items():
+            if not _ly.suppressed:
+                has_comp = True
+                break
+    except:
+        pass
+    has_orient = False
+    try:
+        if len(part.orientations.keys()) > 0:
+            has_orient = True
+    except:
+        pass
+    if has_comp or has_orient:
+        raise ValueError("Composite layup or elemental orientation detected. CAE files do not contain elemental orientations for each element. Please write input and use the input file to run SwiftComp.")
+
     if nSG == 2:
         nMaxnode_elem  = 9
-        nodeinfoFormat = strFormat('dFF') #'{0[0]:8d}{0[1]:16.6E}{0[2]:16.6E}}\n'
+        nodeinfoFormat = strFormat('dFF')
         eleminfoFormat = eleFormat('dd','d'*9)
     elif nSG == 3:
         nMaxnode_elem  = 20
-        nodeinfoFormat = strFormat('dFFF') #'{0[0]:8d}{1[0]:16.6E}{1[1]:16.6E}{2[2]:16.6E}\n'
+        nodeinfoFormat = strFormat('dFFF')
         eleminfoFormat = eleFormat('dd','d'*20)
 
     #### start to write
-    
     if new_filename == '':
         swiftcomp_filename = part_name + '_nSG' + str(nSG) + '_' + macro_model_dimension + '_' + str(elements[0].type)
     else:
@@ -58,7 +76,7 @@ def generateInputFromCAE(model_source, macro_model_dimension, analysis, elem_fla
     else:
         apstr = ''.join(map(str, apvector))
         apstr = 'MIX'+apstr
-    swiftcomp_filename = swiftcomp_filename+apstr
+    swiftcomp_filename = swiftcomp_filename + apstr
     
     mdb.customData.Repository('sgs', Sg)
     sg_name = swiftcomp_filename
@@ -72,7 +90,7 @@ def generateInputFromCAE(model_source, macro_model_dimension, analysis, elem_fla
                 apstr)
     if info == 1:
         print('--> Create sg model: %s' % sg_name)
-        print('    mdb.customData.sgs[\'%s\']' %sg_name)
+        print('    mdb.customData.sgs[\'%s\']' % sg_name)
         prettyPrint(sg, 2)
         print('------------------------------')
     
@@ -92,7 +110,7 @@ def generateInputFromCAE(model_source, macro_model_dimension, analysis, elem_fla
         writeFormat(file, 'EE', cos)
         file.write('\n')  
         
-    writeFormat(file, 'd'*4, [analysis,elem_flag,trans_flag,temp_flag])
+    writeFormat(file, 'd'*4, [analysis, elem_flag, trans_flag, temp_flag])
     file.write('\n')
     
     if apvector != [0,0,0]:
@@ -102,20 +120,16 @@ def generateInputFromCAE(model_source, macro_model_dimension, analysis, elem_fla
     nnode = len(nodes)
     nelem = len(elements)
     
-    #read number of exploited materials
-    matSections = part.sectionAssignments
-    
+    # materials from section assignments (isotropic only in CAE path)
     matDict = {}
+    matSections = part.sectionAssignments
     for sec in matSections:
         if sec.suppressed == False:
-            #regionName = sec.region[0]
             secName = sec.sectionName
-            matName = model.sections[secName].material
-            
-            if matName not in matDict:
-                matDict[matName] = len(matDict) + 1
-    
-    # check the validity of materials: matDict
+            mname   = model.sections[secName].material
+            if mname not in matDict:
+                matDict[mname] = len(matDict) + 1
+
     checkMaterials(matDict, analysis, model_name)
                 
     nmate  = len(matDict)
@@ -126,7 +140,7 @@ def generateInputFromCAE(model_source, macro_model_dimension, analysis, elem_fla
     ntemp = 1
     temperature = 0
     
-    writeFormat(file, 'd'*6, [nSG,nnode,nelem,nmate,nslave,nlayer])
+    writeFormat(file, 'd'*6, [nSG, nnode, nelem, nmate, nslave, nlayer])
     file.write('\n')
         
     # write node info
@@ -134,13 +148,13 @@ def generateInputFromCAE(model_source, macro_model_dimension, analysis, elem_fla
     nodeStartTime = time.perf_counter()
 
     if nSG == 3:
-         for i in range(0, nnode):
-             ndCoords = nodes[i].coordinates
-             file.write(nodeinfoFormat.format([nodes[i].label, ndCoords[0], ndCoords[1], ndCoords[2]]))
+        for i in range(0, nnode):
+            ndCoords = nodes[i].coordinates
+            file.write(nodeinfoFormat.format([nodes[i].label, ndCoords[0], ndCoords[1], ndCoords[2]]))
     elif nSG == 2:    
-         for i in range(0, nnode):
-             ndCoords = nodes[i].coordinates    
-             file.write(nodeinfoFormat.format([nodes[i].label,ndCoords[1], ndCoords[2]]))
+        for i in range(0, nnode):
+            ndCoords = nodes[i].coordinates    
+            file.write(nodeinfoFormat.format([nodes[i].label, ndCoords[1], ndCoords[2]]))
              
     nodeEndTime   = time.perf_counter()
     writeNodetime = nodeEndTime - nodeStartTime
@@ -150,55 +164,37 @@ def generateInputFromCAE(model_source, macro_model_dimension, analysis, elem_fla
     
     elemStartTime = time.perf_counter()
 
-    #record element info
     labellist   = []
     matIDlist   = []
     connectlist = []
     
-    matSections = part.sectionAssignments
     for sec in matSections:
         if not sec.suppressed:
             regionName = sec.region[0]
-            secName = sec.sectionName
-        
-        matID = matDict[model.sections[secName].material]
-        
+            secName    = sec.sectionName
+        mid = matDict[model.sections[secName].material]
         setElem = part.sets[regionName].elements
-        
         for elem in setElem:
-            connect = elem.connectivity
-            n_connect = len(connect)
             labellist.append(elem.label)
-            matIDlist.append(matID)
-            ele_connectlist = []
-            
+            matIDlist.append(mid)
+            conn = list(elem.connectivity)
+            n_connect = len(conn)
             if nSG == 3:
-                nsc_connect = n_connect
-                for n in range(n_connect): 
-                    ele_connectlist.append(nodes[connect[n]].label)
-                    
-                if  n_connect == 10:  #if element type is C3D10M, insert a '0' before the 5th node in the element
-                    ele_connectlist.insert(4, 0)
-                    nsc_connect = 11
-                zeros = [0]*(nMaxnode_elem - nsc_connect)
-                ele_connectlist += zeros
-
-                connectlist.append(ele_connectlist)
-                    
+                out = [nodes[n].label for n in conn]
+                et  = str(elem.type).upper()
+                if et.startswith('C3D15') and n_connect == 15:
+                    out.insert(6, 0)
+                elif n_connect == 10:
+                    out.insert(4, 0)
+                out += [0]*(nMaxnode_elem - len(out))
+                connectlist.append(out)
             elif nSG == 2:
-                nsc_connect = n_connect
-                for n in range(n_connect): 
-                    ele_connectlist.append(nodes[connect[n]].label)
-                    
-                if  n_connect == 6:  #if element type is STRI65 or CPS6M etc. with 6 nodes, insert a '0' before the 4th node in the element
-                    ele_connectlist.insert(3, 0)
-                    nsc_connect = 7
-                zeros = [0]*(nMaxnode_elem - nsc_connect)
-                ele_connectlist += zeros
-
-                connectlist.append(ele_connectlist)
+                out = [nodes[n].label for n in conn]
+                if n_connect == 6:
+                    out.insert(3, 0)
+                out += [0]*(nMaxnode_elem - len(out))
+                connectlist.append(out)
                 
-    # sort and write element info
     combinedList = list(zip(labellist, matIDlist, connectlist))
     combinedList.sort()
     for elem_info in combinedList:

--- a/scripts/py3/scLocalDB.py
+++ b/scripts/py3/scLocalDB.py
@@ -1,453 +1,578 @@
 # -*- coding: utf-8 -*-
 
-#from abaqusConstants import *
 from abaqusGui import *
-#from kernelAccess import mdb, session
+# from kernelAccess import mdb, session
 import os
 
 thisPath = os.path.abspath(__file__)
-thisDir = os.path.dirname(thisPath)
+thisDir  = os.path.dirname(thisPath)
 
+# Show only CAE SGs that have a real .sc in the work directory =====
+def _resolve_sc_for_sg(sg, sg_name):
+    """Return absolute path to the .sc that should be used for this SG, or None."""
+    try:
+        cwd = os.getcwd()
+        swift = getattr(sg, 'swiftcomp_filename', None)
+
+        # 1) <swiftcomp_filename>.sc in work dir (by basename)
+        if swift:
+            p = os.path.join(cwd, os.path.basename(swift) + '.sc')
+            if os.path.isfile(p):
+                return os.path.abspath(p)
+
+        # 2) <sg_name>.sc in work dir
+        p2 = os.path.join(cwd, sg_name + '.sc')
+        if os.path.isfile(p2):
+            return os.path.abspath(p2)
+    except:
+        pass
+    return None
+
+def _valid_cae_sg_names():
+    """Return sorted SG names that have a resolvable .sc file in the current work dir."""
+    try:
+        names = []
+        for name, sg in mdb.customData.sgs.items():
+            if _resolve_sc_for_sg(sg, name):
+                names.append(name)
+        return sorted(names)
+    except:
+        return []
+# =========================================================================================
 
 ###########################################################################
-# Class definition
+# Dialog
 ###########################################################################
 
 class LocalDB(AFXDataDialog):
-    
-    # [
-    #     ID_Macro1D, 
-    #     ID_Macro2D, 
-    #     ID_Macro3D, 
-    #     ID_AnalysisNonThermal, 
-    #     ID_AnalysisThermal, 
-    #     ID_LAST
-    # ] = range(AFXToolsetGui.ID_LAST, AFXToolsetGui.ID_LAST + 6)
 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def __init__(self, form):
 
-        # Construct the base class.
-        #
+        AFXDataDialog.__init__(
+            self, form, 'Dehomogenization',
+            self.OK | self.CANCEL, DIALOG_ACTIONS_SEPARATOR
+        )
 
-        AFXDataDialog.__init__(self, form, 'Dehomogenization',
-            self.OK|self.CANCEL, DIALOG_ACTIONS_SEPARATOR)
+        # Make the window resizable and big enough that OK/Cancel are visible
+        try:
+            self.setDecorations(self.getDecorations() | DECOR_RESIZE)
+        except: pass
+        try:
+            self.resize(max(self.getDefaultWidth(), 560), 760)
+        except: pass
+
         self.form = form
-        w = 100  # width of table columns
+        colw = 100  # AFXTable column width
 
-        okBtn = self.getActionButton(self.ID_CLICKED_OK)
-        okBtn.setText('OK')
-        
-        GroupBox_0 = FXGroupBox(p=self, text='SG model source',
-                                opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        hf_source = FXHorizontalFrame(p=GroupBox_0, opts=0, x=0, y=0, w=0, h=0,
-                                      pl=0, pr=0, pt=0, pb=0)
-        
-        FXRadioButton(p=hf_source, text='CAE',
-                      tgt=form.sgmodel_sourceKw, sel=1)
-        FXRadioButton(p=hf_source, text='SwiftComp Input file',
-                      tgt=form.sgmodel_sourceKw, sel=2)
-        
-        
-        self.swt_source = FXSwitcher(self, LAYOUT_FILL_X,
-                                     0, 0, 0, 0, 0, 0, 0, 0)
-        
-        #--------------------------------------------------------------------
-        # if sgmodel_sourceKw==1:  from CAE
-        listVf = FXVerticalFrame(
-            p=self.swt_source,
-            opts=FRAME_SUNKEN|FRAME_THICK|LAYOUT_FILL_X, 
-            x=0, y=0, w=0, h=0, pl=0, pr=0, pt=0, pb=0)
-            
-        # Note: Set the selector to indicate that this widget should not be
-        #       colored differently from its parent when the 'Color layout managers'
-        #       button is checked in the RSG Dialog Builder dialog.
-        listVf.setSelector(99)
+        # Remember last error so we don't spam dialogs
+        self._last_error_key = None
+        self._last_sg_name   = ''  # to detect selection changes
+        self._last_source    = None  # to detect CAE/SC switching
+
+        # ---------------- Top controls (non-scrolling) ----------------
+        srcGB = FXGroupBox(self, 'SG model source', FRAME_GROOVE | LAYOUT_FILL_X)
+        hf    = FXHorizontalFrame(srcGB, 0, 0,0,0,0, 0,0,0,0)
+        FXRadioButton(hf, 'CAE',                   self.form.sgmodel_sourceKw, 1)
+        FXRadioButton(hf, 'SwiftComp Input file',  self.form.sgmodel_sourceKw, 2)
+
+        self.swt_source = FXSwitcher(self, LAYOUT_FILL_X, 0,0,0,0, 0,0,0,0)
+
+        # ===== CAE PANEL =====
+        caeVF = FXVerticalFrame(self.swt_source, FRAME_SUNKEN|FRAME_THICK|LAYOUT_FILL_X)
+        caeVF.setSelector(99)
+
         self.List_sg = AFXList(
-            p=listVf, nvis=8, tgt=form.sg_nameKw, sel=0, 
-            opts=HSCROLLING_OFF|LIST_SINGLESELECT|LAYOUT_FILL_X)
-        
-#        msgCount = 169
-#        form.model_nameKw.setTarget(self)
-#        form.model_nameKw.setSelector(AFXDataDialog.ID_LAST+msgCount)
-#        msgHandler = str(self.__class__).split('.')[-1] + '.onComboBox_1PartsChanged'
-#        exec('FXMAPFUNC(self, SEL_COMMAND, AFXDataDialog.ID_LAST+%d, %s)' % (msgCount, msgHandler) )
-        
-        
-        names = list(mdb.customData.sgs.keys())
-        names.sort()
-        for name in names:
-            self.List_sg.appendItem(name)
-        
-        if not form.sg_nameKw.getValue() in names:
-            if len(names) !=0:
-                form.sg_nameKw.setValue( names[0] )
-        else:
-            form.sg_nameKw.setValue('')
-        
-        
-        
-        #----------------------------------------------------------------------
-        # if sgmodel_sourceKw==2:  from SwiftComp Input file
-        VFrame_1 = FXVerticalFrame(
-            p=self.swt_source,
-            opts=0, x=0, y=0, w=0, h=0, pl=0, pr=0, pt=0, pb=0)
-        VAligner_1 = AFXVerticalAligner(
-            p=VFrame_1,
-            opts=0, x=0, y=0, w=0, h=0, pl=0, pr=0, pt=0, pb=0)
-        fileHandler = LocalDBFileHandler(form, 'sc_input', 'SC Input (*.sc)')
-        fileTextHf = FXHorizontalFrame(
-            p=VAligner_1,
-            opts=0, x=0, y=0, w=0, h=0, pl=0, pr=0, pt=0, pb=0,
-            hs=DEFAULT_SPACING, vs=DEFAULT_SPACING)
-        # Note: Set the selector to indicate that this widget should not be
-        #       colored differently from its parent when the 'Color layout managers'
-        #       button is checked in the RSG Dialog Builder dialog.
-        fileTextHf.setSelector(99)
-        AFXTextField(
-            p=fileTextHf, ncols=26, labelText='SwiftComp input file: ',
-            tgt=form.sc_inputKw, sel=0,
-            opts=AFXTEXTFIELD_STRING|LAYOUT_CENTER_Y)
+            caeVF, nvis=8, tgt=self.form.sg_nameKw, sel=0,
+            opts=HSCROLLING_OFF | LIST_SINGLESELECT | LAYOUT_FILL_X
+        )
+
+        # CAE: user controls only strain/stress (uses SAME keyword as SC)
+        self.ComboBox_measure_cae = AFXComboBox(
+            caeVF, ncols=28, nvis=1, text='Generalized strain/stress: ',
+            tgt=self.form.load_measureKw, sel=0
+        )
+        self.ComboBox_measure_cae.setMaxVisible(2)
+        self.ComboBox_measure_cae.appendItem('Strain', 1)
+        self.ComboBox_measure_cae.appendItem('Stress', 0)
+
+        # Populate CAE list with only SGs that have a real .sc in work dir
+        self._refresh_sg_list()
+        # --------------------------------------------------------------------------
+
+        # ===== SwiftComp PANEL =====
+        scVF  = FXVerticalFrame(self.swt_source)
+        align = AFXVerticalAligner(scVF)
+
+        fh = LocalDBFileHandler(self.form, 'sc_input', 'SC Input (*.sc)')
+        fileHF = FXHorizontalFrame(align, hs=DEFAULT_SPACING, vs=DEFAULT_SPACING)
+        fileHF.setSelector(99)
+        AFXTextField(fileHF, 26, 'SwiftComp input file: ',
+                     self.form.sc_inputKw, 0, AFXTEXTFIELD_STRING | LAYOUT_CENTER_Y)
         icon = afxGetIcon('fileOpen', AFX_ICON_SMALL)
-        FXButton(p=fileTextHf, text='\tSelect File\nFrom Dialog',
-                 ic=icon, tgt=fileHandler, sel=AFXMode.ID_ACTIVATE,
-                 opts=BUTTON_NORMAL|LAYOUT_CENTER_Y,
-                 x=0, y=0, w=0, h=0, pl=1, pr=1, pt=1, pb=1)
+        FXButton(fileHF, '\tSelect File\nFrom Dialog', icon, fh,
+                 AFXMode.ID_ACTIVATE, BUTTON_NORMAL | LAYOUT_CENTER_Y, 0,0,0,0,1,1,1,1)
 
-        # ----Analysis type--------
-        ComboBox_4 = AFXComboBox(
-            p=VAligner_1, ncols=28, nvis=1, text='Analysis type: ', 
-            tgt=form.analysisKw, sel=0)
-        ComboBox_4.setMaxVisible(10)
-        ComboBox_4.appendItem(text='Elastic', sel=0)
-        ComboBox_4.appendItem(text='ThermoElastic', sel=1)
-        ComboBox_4.appendItem(text='Conduction', sel=2)
-        ComboBox_4.appendItem(text='PiezoElectric', sel=3)
-        ComboBox_4.appendItem(text='PiezoMagnetic', sel=33)
-        ComboBox_4.appendItem(text='ThermoPiezoElectric', sel=4)
-        ComboBox_4.appendItem(text='ThermoPiezoMagnetic', sel=44)
-        ComboBox_4.appendItem(text='PiezoElectroMagnetic', sel=5)
-        ComboBox_4.appendItem(text='ThermoPiezoElectroMagnetic', sel=6)
-        # ------------------------------------------------------------
-        ComboBox_1 = AFXComboBox(
-            p=VAligner_1, ncols=28, nvis=1, text='Macroscopic model: ',
-            tgt=form.macro_modelKw, sel=0)
-        ComboBox_1.setMaxVisible(10)
-        ComboBox_1.appendItem(text='1D (Beam)', sel=1)
-        ComboBox_1.appendItem(text='2D (Shell)', sel=2)
-        ComboBox_1.appendItem(text='3D (Solid)', sel=3)
+        # Analysis type
+        cb_ana = AFXComboBox(align, 28, 1, 'Analysis type: ', self.form.analysisKw, 0)
+        cb_ana.setMaxVisible(10)
+        cb_ana.appendItem('Elastic', 0)
+        cb_ana.appendItem('ThermoElastic', 1)
+        cb_ana.appendItem('Conduction', 2)
+        cb_ana.appendItem('PiezoElectric', 3)
+        cb_ana.appendItem('PiezoMagnetic', 33)
+        cb_ana.appendItem('ThermoPiezoElectric', 4)
+        cb_ana.appendItem('ThermoPiezoMagnetic', 44)
+        cb_ana.appendItem('PiezoElectroMagnetic', 5)
+        cb_ana.appendItem('ThermoPiezoElectroMagnetic', 6)
 
-        FXCheckButton(p=VFrame_1, text='Aperiodic',
-                      tgt=form.ap_flagKw, sel=0)
+        # Macro model
+        self.cb_macro = AFXComboBox(align, 28, 1, 'Macroscopic model: ', self.form.macro_modelKw, 0)
+        self.cb_macro.setMaxVisible(10)
+        self.cb_macro.appendItem('1D (Beam)', 1)
+        self.cb_macro.appendItem('2D (Shell)', 2)
+        self.cb_macro.appendItem('3D (Solid)', 3)
 
-        FXHorizontalSeparator(p=self, x=0, y=0, w=0, h=0,
-                              pl=2, pr=2, pt=2, pb=2)
-        
-        # -------------------------------------------------------------------
-        # Macroscopic results -----------------------------------------------
-        l = FXLabel(p=self, text='Macroscopic analysis results', opts=JUSTIFY_LEFT)
-        l.setFont( getAFXFont(FONT_BOLD) )
-        
-        # Displacements......................................................
-        gb_v = FXGroupBox(
-            p=self, text='Displacements',
-            opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        vf_v = FXVerticalFrame(
-            gb_v, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_v = AFXTable(vf_v, 2, 3, 2, 3, form.vKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_v.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_v.setLeadingRows(1)
-        t_v.setLeadingRowLabels('v1\tv2\tv3')
-        t_v.setColumnWidth(-1, w)
-        t_v.setColumnJustify(-1, AFXTable.RIGHT)
-        t_v.showHorizontalGrid(True)
-        t_v.showVerticalGrid(True)
-        
-        # Rotations..........................................................
-        gb_c = FXGroupBox(p=self, text='Rotations', opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        vf_c = FXVerticalFrame(
-            gb_c, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_c = AFXTable(vf_c, 3, 3, 2, 3, form.cKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_c.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_c.setColumnWidth(-1, w)
-        t_c.setColumnJustify(-1, AFXTable.RIGHT)
-        t_c.showHorizontalGrid(True)
-        t_c.showVerticalGrid(True)
-        
-        # Generalized strains................................................
-        gb_e = FXGroupBox(p=self, text='Generalized strains',
-                          opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        self.swt_drs = FXSwitcher(gb_e, 0, 0,0,0,0, 0,0,0,0)
-        # 1D........
-        vf_1d = FXVerticalFrame(self.swt_drs, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        vf_be = FXVerticalFrame(
-            vf_1d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_be = AFXTable(vf_be, 2, 1, 2, 1, form.beKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_be.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_be.setLeadingRows(1)
-        t_be.setLeadingRowLabels('epsilon11')
-        t_be.setColumnWidth(-1, w)
-        t_be.setColumnJustify(-1, AFXTable.RIGHT)
-        t_be.showHorizontalGrid(True)
-        t_be.showVerticalGrid(True)
+        # Measure (same keyword as CAE)
+        self.cb_measure_sc = AFXComboBox(
+            align, 28, 1, 'Generalized strain/stress: ', self.form.load_measureKw, 0)
+        self.cb_measure_sc.setMaxVisible(2)
+        self.cb_measure_sc.appendItem('Strain', 1)
+        self.cb_measure_sc.appendItem('Stress', 0)
 
-        vf_bk = FXVerticalFrame(
-            vf_1d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_bk = AFXTable(vf_bk, 2, 3, 2, 3, form.bkKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_bk.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_bk.setLeadingRows(1)
-        t_bk.setLeadingRowLabels('kappa11\tkappa12\tkappa13')
-        t_bk.setColumnWidth(-1, w)
-        t_bk.setColumnJustify(-1, AFXTable.RIGHT)
-        t_bk.showHorizontalGrid(True)
-        t_bk.showVerticalGrid(True)
-        
-        # 2D........
-        vf_2d = FXVerticalFrame(self.swt_drs, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        vf_se = FXVerticalFrame(
-            vf_2d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_se = AFXTable(vf_se, 2, 3, 2, 3, form.seKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_se.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_se.setLeadingRows(1)
-        t_se.setLeadingRowLabels('epsilon11\t2epsilon12\tepsilon22')
-        t_se.setColumnWidth(-1, w)
-        t_se.setColumnJustify(-1, AFXTable.RIGHT)
-        t_se.showHorizontalGrid(True)
-        t_se.showVerticalGrid(True)
+        # Beam/Shell type rows (SwiftComp only; CAE deduces automatically)
+        self.beamRow  = FXHorizontalFrame(align);  self.beamRow.hide()
+        self.cb_beam  = AFXComboBox(self.beamRow, 28, 1, 'Beam model: ', self.form.beam_modelKw, 0)
+        self.cb_beam.setMaxVisible(2)
+        self.cb_beam.appendItem('Euler', 1)
+        self.cb_beam.appendItem('Timoshenko', 2)
 
-        vf_sk = FXVerticalFrame(
-            vf_2d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_sk = AFXTable(vf_sk, 2, 3, 2, 3, form.skKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_sk.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_sk.setLeadingRows(1)
-        t_sk.setLeadingRowLabels('kappa11\tkappa12+21\tkappa22')
-        t_sk.setColumnWidth(-1, w)
-        t_sk.setColumnJustify(-1, AFXTable.RIGHT)
-        t_sk.showHorizontalGrid(True)
-        t_sk.showVerticalGrid(True)
-        
-        # 3D........
-        vf_3d = FXVerticalFrame(self.swt_drs, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        vf_en = FXVerticalFrame(
-            vf_3d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_en = AFXTable(vf_en, 2, 3, 2, 3, form.enKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_en.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_en.setLeadingRows(1)
-        t_en.setLeadingRowLabels('epsilon11\tepsilon22\tepsilon33')
-        t_en.setColumnWidth(-1, w)
-        t_en.setColumnJustify(-1, AFXTable.RIGHT)
-        t_en.showHorizontalGrid(True)
-        t_en.showVerticalGrid(True)
+        self.shellRow = FXHorizontalFrame(align);  self.shellRow.hide()
+        self.cb_shell = AFXComboBox(self.shellRow, 28, 1, 'Shell model: ', self.form.shell_modelKw, 0)
+        self.cb_shell.setMaxVisible(2)
+        self.cb_shell.appendItem('Kirchhoff', 1)
+        self.cb_shell.appendItem('Mindlin',  2)
 
-        vf_es = FXVerticalFrame(
-            vf_3d, FRAME_SUNKEN|FRAME_THICK,
-            0, 0, 0, 0, 0, 0, 0, 0)
-        t_es = AFXTable(vf_es, 2, 3, 2, 3, form.esKw, 0,
-                       AFXTABLE_EDITABLE|LAYOUT_FILL_X)
-        t_es.setPopupOptions(
-            AFXTable.POPUP_COPY|AFXTable.POPUP_CUT|AFXTable.POPUP_PASTE)
-        t_es.setLeadingRows(1)
-        t_es.setLeadingRowLabels('2epsilon23\t2epsilon13\t2epsilon12')
-        t_es.setColumnWidth(-1, w)
-        t_es.setColumnJustify(-1, AFXTable.RIGHT)
-        t_es.showHorizontalGrid(True)
-        t_es.showVerticalGrid(True)
-        
-        # Additional inputs................................................
-        GroupBox_4 = FXGroupBox(p=self, text='Additional inputs',
-                                opts=FRAME_GROOVE|LAYOUT_FILL_X)
-        
-        # temperature........
-        HFrame_6=FXHorizontalFrame(p=GroupBox_4, opts=LAYOUT_FILL_X, x=0, y=0, w=0, h=0,
-            pl=0, pr=0, pt=0, pb=0)
-        VAligner_14 = AFXVerticalAligner(p=HFrame_6, opts=0, x=0, y=0, w=0, h=0,
-            pl=0, pr=0, pt=0, pb=0)
-        self.tempdiff = AFXTextField(
-            p=VAligner_14, ncols=12, labelText='temperature increment',
-            tgt=form.tmKw, sel=0)
+        FXCheckButton(scVF, 'Aperiodic', self.form.ap_flagKw, 0)
 
-        
-        #---------------------------------------------------------------------
-        
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_Macro1D, LocalDB.onMacro1D)
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_Macro2D, LocalDB.onMacro2D)
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_Macro3D, LocalDB.onMacro3D)
-        
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_AnalysisNonThermal,
-        #           LocalDB.onAnalysisNonThermal)
-        # FXMAPFUNC(self, SEL_COMMAND, self.ID_AnalysisThermal,
-        #           LocalDB.onAnalysisThermal)
-        
-        # self.addTransition(
-        #     form.macro_modelKw, AFXTransition.EQ, 1, self,
-        #     MKUINT(self.ID_Macro1D, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.macro_modelKw, AFXTransition.EQ, 2, self,
-        #     MKUINT(self.ID_Macro2D, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.macro_modelKw, AFXTransition.EQ, 3, self,
-        #     MKUINT(self.ID_Macro3D, SEL_COMMAND), None)
-                           
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 0, self,
-        #     MKUINT(self.ID_AnalysisNonThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 2, self,
-        #     MKUINT(self.ID_AnalysisNonThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 3, self,
-        #     MKUINT(self.ID_AnalysisNonThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 5, self,
-        #     MKUINT(self.ID_AnalysisNonThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 1, self,
-        #     MKUINT(self.ID_AnalysisThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 4, self,
-        #     MKUINT(self.ID_AnalysisThermal, SEL_COMMAND), None)
-        # self.addTransition(
-        #     form.analysisKw, AFXTransition.EQ, 6, self,
-        #     MKUINT(self.ID_AnalysisThermal, SEL_COMMAND), None)
+        FXHorizontalSeparator(self, 2,2,2,2)
 
-    
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # ---------------- Scrolling content ----------------
+        scroll  = FXScrollWindow(self, LAYOUT_FILL_X|LAYOUT_FILL_Y|VSCROLLER_ALWAYS|HSCROLLER_NEVER)
+        content = FXVerticalFrame(scroll, FRAME_NONE|LAYOUT_FILL_X|LAYOUT_FILL_Y)
+
+        # Title
+        t = FXLabel(p=content, text='Macroscopic analysis results', opts=JUSTIFY_LEFT)
+        t.setFont(getAFXFont(FONT_BOLD))
+
+        # Displacements
+        gb_v = FXGroupBox(content, 'Displacements', FRAME_GROOVE|LAYOUT_FILL_X)
+        vf_v = FXVerticalFrame(gb_v, FRAME_SUNKEN|FRAME_THICK)
+        tv   = AFXTable(vf_v, 2,3, 2,3, self.form.vKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tv.setLeadingRows(1); tv.setLeadingRowLabels('v1\tv2\tv3')
+        tv.setColumnWidth(-1, colw); tv.setColumnJustify(-1, AFXTable.RIGHT)
+        tv.showHorizontalGrid(True); tv.showVerticalGrid(True)
+
+        # Rotations
+        gb_c = FXGroupBox(content, 'Rotations', FRAME_GROOVE|LAYOUT_FILL_X)
+        vf_c = FXVerticalFrame(gb_c, FRAME_SUNKEN|FRAME_THICK)
+        tc   = AFXTable(vf_c, 3,3, 2,3, self.form.cKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tc.setColumnWidth(-1, colw); tc.setColumnJustify(-1, AFXTable.RIGHT)
+        tc.showHorizontalGrid(True); tc.showVerticalGrid(True)
+
+        # Generalized inputs (switchers)
+        gb_g   = FXGroupBox(content, 'Generalized inputs', FRAME_GROOVE|LAYOUT_FILL_X)
+        self.swt_dim = FXSwitcher(gb_g)  # 1D / 2D / 3D
+
+        # 1D switcher: 0 Euler strain, 1 Euler stress, 2 Timo strain, 3 Timo stress
+        f1d = FXVerticalFrame(self.swt_dim)
+        self.swt_1d = FXSwitcher(f1d)
+
+        # Euler STRAIN: be=[ε11], bk=[κ11 κ12 κ13]
+        f_1d_es = FXVerticalFrame(self.swt_1d)
+        vf = FXVerticalFrame(f_1d_es, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,1, 2,1, self.form.beKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11')
+        vf2 = FXVerticalFrame(f_1d_es, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.bkKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('kappa11\tkappa12\tkappa13')
+
+        # Euler STRESS: be=[F1], bk=[M1 M2 M3]
+        f_1d_eF = FXVerticalFrame(self.swt_1d)
+        vf = FXVerticalFrame(f_1d_eF, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,1, 2,1, self.form.beKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('F1')
+        vf2 = FXVerticalFrame(f_1d_eF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.bkKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('M1\tM2\tM3')
+
+        # Timoshenko STRAIN: be=[ε11 γ12 γ13], bk=[κ11 κ12 κ13]
+        f_1d_ts = FXVerticalFrame(self.swt_1d)
+        vf = FXVerticalFrame(f_1d_ts, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.beKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11\tgamma12\tgamma13')
+        vf2 = FXVerticalFrame(f_1d_ts, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.bkKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('kappa11\tkappa12\tkappa13')
+
+        # Timoshenko STRESS: be=[F1 F2 F3], bk=[M1 M2 M3]
+        f_1d_tF = FXVerticalFrame(self.swt_1d)
+        vf = FXVerticalFrame(f_1d_tF, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.beKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('F1\tF2\tF3')
+        vf2 = FXVerticalFrame(f_1d_tF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.bkKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('M1\tM2\tM3')
+
+        # 2D switcher: 0 KL strain, 1 KL stress, 2 Mindlin strain, 3 Mindlin stress
+        f2d = FXVerticalFrame(self.swt_dim)
+        self.swt_2d = FXSwitcher(f2d)
+
+        # Kirchhoff STRAIN
+        f_2d_ks = FXVerticalFrame(self.swt_2d)
+        vf = FXVerticalFrame(f_2d_ks, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.seKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11\t2epsilon12\tepsilon22')
+        vf2 = FXVerticalFrame(f_2d_ks, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.skKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('kappa11\t2kappa12\tkappa22')
+
+        # Kirchhoff STRESS
+        f_2d_kF = FXVerticalFrame(self.swt_2d)
+        vf = FXVerticalFrame(f_2d_kF, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.seKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('N11\tN22\tN12')
+        vf2 = FXVerticalFrame(f_2d_kF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.skKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('M11\tM22\tM12')
+
+        # Mindlin STRAIN (adds γ13 γ23 in esKw)
+        f_2d_ms = FXVerticalFrame(self.swt_2d)
+        vf = FXVerticalFrame(f_2d_ms, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.seKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11\t2epsilon12\tepsilon22')
+        vf2 = FXVerticalFrame(f_2d_ms, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.skKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('kappa11\t2kappa12\tkappa22')
+        vf3 = FXVerticalFrame(f_2d_ms, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf3, 2,2, 2,2, self.form.esKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('gamma13\tgamma23')
+
+        # Mindlin STRESS (adds N13 N23 in esKw)
+        f_2d_mF = FXVerticalFrame(self.swt_2d)
+        vf = FXVerticalFrame(f_2d_mF, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.seKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('N11\tN22\tN12')
+        vf2 = FXVerticalFrame(f_2d_mF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.skKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('M11\tM22\tM12')
+        vf3 = FXVerticalFrame(f_2d_mF, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf3, 2,2, 2,2, self.form.esKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('N13\tN23')
+
+        # 3D switcher: 0 strain, 1 stress
+        f3d = FXVerticalFrame(self.swt_dim)
+        self.swt_3d = FXSwitcher(f3d)
+
+        f_3d_s = FXVerticalFrame(self.swt_3d)
+        vf = FXVerticalFrame(f_3d_s, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.enKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('epsilon11\tepsilon22\tepsilon33')
+        vf2 = FXVerticalFrame(f_3d_s, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.esKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('2epsilon23\t2epsilon13\t2epsilon12')
+
+        f_3d_F = FXVerticalFrame(self.swt_3d)
+        vf = FXVerticalFrame(f_3d_F, FRAME_SUNKEN|FRAME_THICK)
+        tb = AFXTable(vf, 2,3, 2,3, self.form.enKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('sigma11\tsigma22\tsigma33')
+        vf2 = FXVerticalFrame(f_3d_F, FRAME_SUNKEN|FRAME_THICK)
+        tb  = AFXTable(vf2, 2,3, 2,3, self.form.esKw, 0, AFXTABLE_EDITABLE|LAYOUT_FILL_X)
+        tb.setLeadingRows(1); tb.setLeadingRowLabels('sigma23\tsigma13\tsigma12')
+
+        # Additional inputs
+        addGB = FXGroupBox(content, 'Additional inputs', FRAME_GROOVE|LAYOUT_FILL_X)
+        addHF = FXHorizontalFrame(addGB, LAYOUT_FILL_X)
+        addVA = AFXVerticalAligner(addHF)
+        self.tempdiff = AFXTextField(addVA, 12, 'temperature increment', self.form.tmKw, 0)
+
+    # Repopulate the CAE SG list with only valid names --------
+    def _refresh_sg_list(self):
+        try:
+            valid = _valid_cae_sg_names()
+            # clear and repopulate list
+            try:
+                self.List_sg.clearItems()
+            except:
+                pass
+            for nm in valid:
+                self.List_sg.appendItem(nm)
+            # set keyword to first valid (or empty)
+            if valid:
+                if self.form.sg_nameKw.getValue() not in valid:
+                    self.form.sg_nameKw.setValue(valid[0])
+            else:
+                self.form.sg_nameKw.setValue('')
+        except:
+            pass
+    # ----------------------------------------------------------------------
+
+    # -------- Helpers --------
+    def _toggle_specific(self, macro_model_int):
+        if macro_model_int == 1:
+            self.beamRow.show();  self.shellRow.hide()
+        elif macro_model_int == 2:
+            self.beamRow.hide();  self.shellRow.show()
+        else:
+            self.beamRow.hide();  self.shellRow.hide()
+        try:
+            self.beamRow.recalc(); self.shellRow.recalc()
+            self.layout(); self.update()
+        except: pass
+
+    def _error(self, title, msg):
+        try:
+            showAFXErrorDialog(getAFXApp().getAFXMainWindow(), '%s\n\n%s' % (title, msg))
+        except:
+            try:
+                AFXMessageDialog(getAFXApp().getAFXMainWindow(),
+                                 self, AFXMessageDialog.ERROR, title, msg).create().showModal()
+            except:
+                print('[ERROR] %s: %s' % (title, msg))
+
+    # Show an error only once per unique "key"
+    def _error_once(self, title, msg, key):
+        if key == self._last_error_key:
+            return
+        self._last_error_key = key
+        self._error(title, msg)
+
+    def _determine_model_from_cae(self, sg_name):
+        """Return (macro_model_int, model_string). Enforces that a real .sc exists.
+           Uses numeric specific_model when available; falls back to model strings."""
+        # 0) fetch SG
+        try:
+            sg = mdb.customData.sgs[sg_name]
+        except:
+            self._error_once('CAE model',
+                             'Selected SG cannot be found in mdb.customData.sgs.',
+                             key=('missing_sg', sg_name))
+            return (None, None)
+
+        # 1) MUST have a usable .sc file in current work directory
+        sc_path = _resolve_sc_for_sg(sg, sg_name)
+        if not sc_path:
+            self._error_once(
+                'SwiftComp file not found',
+                ("The selected CAE SG requires a matching .sc file in the current work directory.\n"
+                 "Set the work directory to the folder containing the .sc and try again, "
+                 "or re-export homogenization."),
+                key=('missing_sc', sg_name)
+            )
+            return (None, None)
+
+        # 2) dimension
+        try:
+            dim = (getattr(sg, 'macro_model_dimension', '') or '').strip()
+            macro = int(dim.strip('D')) if dim else None
+        except:
+            macro = None
+
+        # 3) prefer numeric specific_model (0/1). fall back to strings.
+        sm = getattr(sg, 'specific_model', None)
+        beam  = (getattr(sg, 'beam_model',  '') or '').strip()
+        shell = (getattr(sg, 'shell_model', '') or '').strip()
+        model = (getattr(sg, 'model',       '') or '').strip()
+        nm = (sg_name or '').lower()
+
+        if macro == 1:
+            # 1D: 0=Euler, 1=Timoshenko
+            if isinstance(sm, (int, long)) if 'long' in dir(__builtins__) else isinstance(sm, int):
+                if sm in (0, 1):
+                    return (1, 'Euler' if sm == 0 else 'Timoshenko')
+            # fallback: strings / name
+            cand = beam or (model if model.lower().startswith(('euler','timo')) else '')
+            if not cand:
+                cand = 'Euler' if 'euler' in nm else ('Timoshenko' if 'timo' in nm else '')
+            if not cand:
+                self._error_once(
+                    'Missing beam model',
+                    'CAE SG is 1D but lacks Euler/Timoshenko info. Re-export with the latest GUI.',
+                    key=('beam_missing', sg_name)
+                ); return (None, None)
+            return (1, 'Euler' if cand.lower().startswith('euler') else 'Timoshenko')
+
+        if macro == 2:
+            # 2D: 0=Kirchhoff, 1=Mindlin
+            if isinstance(sm, (int, long)) if 'long' in dir(__builtins__) else isinstance(sm, int):
+                if sm in (0, 1):
+                    return (2, 'Kirchhoff' if sm == 0 else 'Mindlin')
+            # fallback: strings / name
+            ml = model.lower()
+            cand = shell or (model if ml.startswith(('kirch','mind')) else '')
+            if not cand:
+                cand = 'Kirchhoff' if 'kirch' in nm else ('Mindlin' if ('mind' in nm or 'reissner' in nm) else '')
+            if not cand:
+                self._error_once(
+                    'Missing shell model',
+                    'CAE SG is 2D but lacks Kirchhoff/Mindlin info. Re-export with the latest GUI.',
+                    key=('shell_missing', sg_name)
+                ); return (None, None)
+            return (2, 'Kirchhoff' if cand.lower().startswith('kirch') else 'Mindlin')
+
+        if macro == 3:
+            return (3, '')
+
+        self._error_once(
+            'Unknown macro model',
+            'Could not determine whether the CAE SG is 1D/2D/3D. Re-export with the latest GUI.',
+            key=('macro_unknown', sg_name)
+        )
+        return (None, None)
+
+    # -------- AFXDataDialog overrides --------
     def show(self):
-        
+        # reset error latch every time dialog opens
+        self._last_error_key = None
+        self._last_sg_name   = ''
+        self._last_source    = None
+
+        if self.form.sgmodel_sourceKw.getValue() == 2:
+            self.swt_source.setCurrent(1)
+            self._toggle_specific(self.form.macro_modelKw.getValue())
+        else:
+            self.swt_source.setCurrent(0)
+            self.beamRow.hide(); self.shellRow.hide()
+            # Ensure list is fresh on open in CAE mode
+            self._refresh_sg_list()
+
         self.tempdiff.disable()
-        self.swt_source.setCurrent(0)
         AFXDataDialog.show(self)
 
-        
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    def hide(self):
-
-        AFXDataDialog.hide(self)
-        
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def processUpdates(self):
-        
+        # detect CAE/SC switching; refresh list when CAE is selected
+        try:
+            current_source = self.form.sgmodel_sourceKw.getValue()
+        except:
+            current_source = None
+
+        if current_source != self._last_source:
+            self._last_source = current_source
+            if current_source == 1:  # CAE
+                self._refresh_sg_list()
+
+        # if the selected SG changed, allow a new error to show once
+        sg_now = self.form.sg_nameKw.getValue()
+        if sg_now != self._last_sg_name:
+            self._last_sg_name = sg_now
+            self._last_error_key = None  # clear the latch when user changes selection
+
+        # normalize measure
+        try:
+            measure = int(self.form.load_measureKw.getValue())
+        except:
+            measure = 1 if str(self.form.load_measureKw.getValue()).lower().startswith('strain') else 0
+        is_strain = (measure == 1)
+
         if self.form.sgmodel_sourceKw.getValue() == 1:
+            # -------- CAE mode --------
             self.swt_source.setCurrent(0)
             sg_name = self.form.sg_nameKw.getValue()
-            if sg_name != '':
-                macro_model_d = mdb.customData.sgs[sg_name].macro_model_dimension
-                macro_model = int(macro_model_d.strip('D'))
-                self.swt_drs.setCurrent(macro_model-1)
-                # if macro_model == 1:
-                #     self.swt_drs.setCurrent(0)
-                # elif macro_model == 2:
-                #     self.swt_drs.setCurrent(1)
-                # elif macro_model == 3:
-                #     self.swt_drs.setCurrent(2)
 
-                analysis = mdb.customData.sgs[sg_name].analysis
-                if analysis in [0, 2, 3, 5]:
-                    self.tempdiff.disable()
-                elif analysis in [1, 4, 6]:
-                    self.tempdiff.enable()
+            if not sg_name:
+                self.swt_dim.setCurrent(2)
+                return
+
+            macro, variant = self._determine_model_from_cae(sg_name)
+            if macro is None:
+                return
+
+            self.swt_dim.setCurrent(macro - 1)
+
+            if macro == 1:
+                self.beamRow.hide(); self.shellRow.hide()
+                self.swt_1d.setCurrent(0 if (variant == 'Euler' and is_strain)
+                                       else 1 if (variant == 'Euler' and not is_strain)
+                                       else 2 if (variant == 'Timoshenko' and is_strain)
+                                       else 3)
+            elif macro == 2:
+                self.beamRow.hide(); self.shellRow.hide()
+                self.swt_2d.setCurrent(0 if (variant == 'Kirchhoff' and is_strain)
+                                       else 1 if (variant == 'Kirchhoff' and not is_strain)
+                                       else 2 if (variant == 'Mindlin' and is_strain)
+                                       else 3)
             else:
-                self.swt_drs.setCurrent(2)
-        elif self.form.sgmodel_sourceKw.getValue() == 2:
+                self.beamRow.hide(); self.shellRow.hide()
+                self.swt_3d.setCurrent(0 if is_strain else 1)
+
+            try:
+                analysis = int(getattr(mdb.customData.sgs[sg_name], 'analysis', 0))
+            except:
+                analysis = 0
+            if analysis in (1, 4, 6):
+                self.tempdiff.enable()
+            else:
+                self.tempdiff.disable()
+
+            try:
+                self.swt_1d.recalc(); self.swt_2d.recalc(); self.swt_3d.recalc()
+                self.swt_dim.recalc(); self.layout(); self.update()
+            except: pass
+
+        else:
+            # -------- SwiftComp mode --------
+            # changing source resets error latch
+            if self._last_error_key is not None:
+                self._last_error_key = None
+
             self.swt_source.setCurrent(1)
-            macro_model = self.form.macro_modelKw.getValue()
-            self.swt_drs.setCurrent(macro_model-1)
+            macro = self.form.macro_modelKw.getValue()
+            self._toggle_specific(macro)
+
+            self.swt_dim.setCurrent(macro - 1)
+            if macro == 1:
+                bm = self.form.beam_modelKw.getValue().lower()
+                self.swt_1d.setCurrent(0 if (bm=='euler' and is_strain)
+                                       else 1 if (bm=='euler' and not is_strain)
+                                       else 2 if (bm=='timoshenko' and is_strain)
+                                       else 3)
+            elif macro == 2:
+                sm = self.form.shell_modelKw.getValue().lower()
+                self.swt_2d.setCurrent(0 if (sm=='kirchhoff' and is_strain)
+                                       else 1 if (sm=='kirchhoff' and not is_strain)
+                                       else 2 if (sm in ('mindlin','reissner','reissner–mindlin','reissner-mindlin') and is_strain)
+                                       else 3)
+            else:
+                self.swt_3d.setCurrent(0 if is_strain else 1)
 
             analysis = self.form.analysisKw.getValue()
-            if analysis in [0, 2, 3, 33, 5]:
-                self.tempdiff.disable()
-            elif analysis in [1, 4, 44, 6]:
+            if analysis in (1, 4, 44, 6):
                 self.tempdiff.enable()
-                
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#    def updateComboBox_1Parts(self):
-#
-#        modelName = self.form.model_nameKw.getValue()
-#
-#        # Update the names in the Parts combo
-#        #
-#        self.ComboBox_1.clearItems()
-#        names = mdb.models[modelName].parts.keys()
-#        names.sort()
-#        for name in names:
-#            self.ComboBox_1.appendItem(name)
-#        if names:
-#            if not self.form.part_nameKw.getValue() in names:
-#                self.form.part_nameKw.setValue( names[0] )
-#        else:
-#            self.form.part_nameKw.setValue('')
-#
-#        self.resize( self.getDefaultWidth(), self.getDefaultHeight() )
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onMacro1D(self, sender, sel, ptr):
-    #     
-    #     self.swt_drs.setCurrent(0)
-    #     
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onMacro2D(self, sender, sel, ptr):
-    #     
-    #     self.swt_drs.setCurrent(1)
-    #     
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onMacro3D(self, sender, sel, ptr):
-    #     
-    #     self.swt_drs.setCurrent(2)
-    # 
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onAnalysisNonThermal(self, sender, sel, ptr):
-    #     
-    #     self.tempdiff.disable()
-    #     
-    # #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # def onAnalysisThermal(self, sender, sel, ptr):
-    #     
-    #     self.tempdiff.enable()
-        
-    
+            else:
+                self.tempdiff.disable()
+
+            try:
+                self.swt_1d.layout(); self.swt_2d.layout(); self.swt_3d.layout()
+                self.swt_dim.layout(); self.layout(); self.update()
+            except: pass
+
 ###########################################################################
-# Class definition
+# File selector helper
 ###########################################################################
 
 class LocalDBFileHandler(FXObject):
-
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def __init__(self, form, keyword, patterns='*'):
-
-        self.form = form
-        self.patterns = patterns
-        self.patternTgt = AFXIntTarget(0)
+        self.form      = form
+        self.patterns  = patterns
+        self.patternTgt= AFXIntTarget(0)
         exec('self.fileNameKw = form.%sKw' % keyword)
-        self.readOnlyKw = AFXBoolKeyword(None, 'readOnly', AFXBoolKeyword.TRUE_FALSE)
+        self.readOnlyKw= AFXBoolKeyword(None, 'readOnly', AFXBoolKeyword.TRUE_FALSE)
         FXObject.__init__(self)
         FXMAPFUNC(self, SEL_COMMAND, AFXMode.ID_ACTIVATE, LocalDBFileHandler.activate)
 
-    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def activate(self, sender, sel, ptr):
-
-       fileDb = AFXFileSelectorDialog(getAFXApp().getAFXMainWindow(), 'Select a File',
-           self.fileNameKw, self.readOnlyKw,
-           AFXSELECTFILE_ANY, self.patterns, self.patternTgt)
-       fileDb.setReadOnlyPatterns('*.odb')
-       fileDb.create()
-       fileDb.showModal()
+        dlg = AFXFileSelectorDialog(getAFXApp().getAFXMainWindow(), 'Select a File',
+                                    self.fileNameKw, self.readOnlyKw,
+                                    AFXSELECTFILE_ANY, self.patterns, self.patternTgt)
+        dlg.setReadOnlyPatterns('*.odb')
+        dlg.create()
+        dlg.showModal()

--- a/scripts/py3/scLocalForm.py
+++ b/scripts/py3/scLocalForm.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from abaqusGui import *
-#from abaqusConstants import *
-#import osutils, os
 import scLocalDB
 import importlib
-if importlib.sys.version_info.major < 3: importlib.reload = reload
+if importlib.sys.version_info.major < 3:
+    importlib.reload = reload
 
 
 ###########################################################################
@@ -16,35 +15,38 @@ class LocalForm(AFXForm):
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def __init__(self, owner):
-        
-        # Construct the base class.
-        #
+
         AFXForm.__init__(self, owner)
         self.radioButtonGroups = {}
 
         self.cmd = AFXGuiCommand(
             mode=self, method='localization',
             objectName='scLocalMain', registerQuery=False)
-        pickedDefault = ''
-        self.sgmodel_sourceKw = AFXIntKeyword(
-            self.cmd, 'sgmodel_source', True, 1)
-        self.sg_nameKw = AFXStringKeyword(self.cmd, 'sg_name', True)
-        self.sc_inputKw = AFXStringKeyword(self.cmd, 'sc_input', True, '')
-        self.ap_flagKw = AFXBoolKeyword(
-            self.cmd, 'ap_flag', AFXBoolKeyword.TRUE_FALSE, True, False)
-        self.macro_modelKw = AFXIntKeyword(
-            self.cmd, 'macro_model', True, 3, evalExpression=False)
-        self.analysisKw = AFXIntKeyword(
-            self.cmd, 'analysis', True, 0, evalExpression=False)
 
-        # Displacements
+        # ----- Source selection & file/model fields
+        self.sgmodel_sourceKw = AFXIntKeyword(self.cmd, 'sgmodel_source', True, 2)  # 1=CAE, 2=SC
+        self.sg_nameKw       = AFXStringKeyword(self.cmd, 'sg_name', True)
+        self.sc_inputKw      = AFXStringKeyword(self.cmd, 'sc_input', True, '')
+        self.ap_flagKw       = AFXBoolKeyword(self.cmd, 'ap_flag', AFXBoolKeyword.TRUE_FALSE, True, False)
+
+        # For SC-input mode only (UI decides visibility; values passed to backend)
+        self.macro_modelKw = AFXIntKeyword(self.cmd, 'macro_model', True, 3, evalExpression=False)  # 1,2,3
+        self.analysisKw    = AFXIntKeyword(self.cmd, 'analysis',    True, 0, evalExpression=False)
+
+        # Model sub-options (used only when 1D/2D is chosen in SC mode)
+        self.beam_modelKw  = AFXStringKeyword(self.cmd, 'beam_model',  True, 'Euler')      # Euler / Timoshenko
+        self.shell_modelKw = AFXStringKeyword(self.cmd, 'shell_model', True, 'Kirchhoff')  # Kirchhoff / Mindlin
+
+        # Generalized strain/stress selector (0=stress, 1=strain)
+        self.load_measureKw = AFXIntKeyword(self.cmd, 'load_measure', True, 1, evalExpression=False)
+
+        # Displacements (3) and Rotations (3x3)
         self.vKw = AFXTableKeyword(self.cmd, 'v', True)
         self.vKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
         self.vKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
         self.vKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
         self.vKw.setRow(0, '0.0, 0.0, 0.0')
 
-        # Rotations
         self.cKw = AFXTableKeyword(self.cmd, 'c', True)
         self.cKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
         self.cKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
@@ -53,11 +55,13 @@ class LocalForm(AFXForm):
         self.cKw.setRow(1, '0.0, 1.0, 0.0')
         self.cKw.setRow(2, '0.0, 0.0, 1.0')
 
-        # Strains
-        # 1D
+        # Generalized quantities (tables are reused across views)
+        # 1D: be (ε11 or F1 [+ γ12 γ13 for Timo strain / F2 F3 for stress]), bk (κ11 κ12 κ13 or M1 M2 M3)
         self.beKw = AFXTableKeyword(self.cmd, 'be', True)
         self.beKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
-        self.beKw.setRow(0, '0.0')
+        self.beKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
+        self.beKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
+        self.beKw.setRow(0, '0.0, 0.0, 0.0')
 
         self.bkKw = AFXTableKeyword(self.cmd, 'bk', True)
         self.bkKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
@@ -65,7 +69,7 @@ class LocalForm(AFXForm):
         self.bkKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
         self.bkKw.setRow(0, '0.0, 0.0, 0.0')
 
-        # 2D
+        # 2D: se (membrane 3), sk (bending 3), es reused for Mindlin extra pair or 3D shear triplet
         self.seKw = AFXTableKeyword(self.cmd, 'se', True)
         self.seKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
         self.seKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
@@ -78,7 +82,7 @@ class LocalForm(AFXForm):
         self.skKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
         self.skKw.setRow(0, '0.0, 0.0, 0.0')
 
-        # 3D
+        # 3D: en (normal 3), es (shear 3). For Mindlin extra (N13,N23 or γ13,γ23) we still pass through esKw’s first two entries.
         self.enKw = AFXTableKeyword(self.cmd, 'en', True)
         self.enKw.setColumnType(0, AFXTABLE_TYPE_FLOAT)
         self.enKw.setColumnType(1, AFXTABLE_TYPE_FLOAT)
@@ -91,24 +95,19 @@ class LocalForm(AFXForm):
         self.esKw.setColumnType(2, AFXTABLE_TYPE_FLOAT)
         self.esKw.setRow(0, '0.0, 0.0, 0.0')
 
+        # Temperature increment (used for thermal analyses)
         self.tmKw = AFXFloatKeyword(self.cmd, 'tm', True, 0.0)
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def getFirstDialog(self):
-
-#        import scLocalDB
         importlib.reload(scLocalDB)
         return scLocalDB.LocalDB(self)
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def doCustomChecks(self):
-
-        # Try to set the appropriate radio button on. If the user did
-        # not specify any buttons to be on, do nothing.
-        #
-        for kw1,kw2,d in list(self.radioButtonGroups.values()):
+        for kw1, kw2, d in list(self.radioButtonGroups.values()):
             try:
-                value = d[ kw1.getValue() ]
+                value = d[kw1.getValue()]
                 kw2.setValue(value)
             except:
                 pass
@@ -116,9 +115,4 @@ class LocalForm(AFXForm):
 
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     def okToCancel(self):
-
-        # No need to close the dialog when a file operation (such
-        # as New or Open) or model change is executed.
-        #
         return False
-

--- a/scripts/py3/scLocalMain.py
+++ b/scripts/py3/scLocalMain.py
@@ -21,7 +21,7 @@ def localization(
         sh2='',                    # extra 2 components for Mindlin: γ13 γ23 (strain) or N13 N23 (stress)
         tm=0.0, ap_flag=False,
         beam_model="Euler",        # Euler or Timoshenko (for 1D)
-        shell_model="Kirchhoff"    # Kirchhoff or Mindlin/Reissner–Mindlin (for 2D)
+        shell_model="Kirchhoff"    # Kirchhoff or Mindlin (for 2D)
     ):
     """
     Localization analysis for a SG model or a SwiftComp input file.
@@ -82,10 +82,15 @@ def localization(
 
     mdb.customData.Repository('sgDehomoDataSets', SgDehomoData)
     
-    SCfileName, sc_input, analysis,  macro_model, macro_model_dimension, ap_flag = sgmodel_info(
+    SCfileName, sc_input, analysis,  macro_model, macro_model_dimension, ap_flag, sc_dim, sc_sub = sgmodel_info(
         sgmodel_source=sgmodel_source, sg_name=sg_name, sc_input=sc_input,
         analysis=analysis, macro_model=macro_model, ap_flag=ap_flag)
 
+    dim_ui = {1:"1D", 2:"2D", 3:"3D"}.get(macro_model, str(macro_model))
+    sub_ui = ("Solid" if dim_ui=="3D" else (beam_model if dim_ui=="1D" else shell_model))
+    if sc_dim != dim_ui or sc_sub != sub_ui:
+        raise ValueError("The SwiftComp input file is for %s %s model, but you selected %s %s model."
+                         % (sc_dim, sc_sub, dim_ui, sub_ui))
     
 #-----------------------------------------------------------
     print(sc_input)
@@ -126,7 +131,7 @@ def localization(
             print('shell macroscopic strain and curvatures :' if load_measure==1 else 'shell generalized stress resultants :')
             print(se)
             print('Shell model: %s' % shell_model)
-            if shell_model.lower() in ('mindlin','reissner-mindlin','reissner–mindlin'):
+            if shell_model.lower() in ('mindlin','reissner-mindlin'):
                 print('Mindlin extra pair:')
                 print(mindlin_extra)
         elif macro_model_dimension=='3D':
@@ -150,31 +155,27 @@ def localization(
         # Write generalized quantities by dimensional model
         if macro_model_dimension == '1D':
             # be contains [e11, k11, k12, k13] OR for stress [F1, M1, M2, M3] if user entered that order
-            writeFormat(fout, 'E'*4, be)
+            fout.write(" ".join(str(float(x)) for x in be) + "\n")
             # For Timoshenko we don't need to force placeholders; GUI provides correct triplets in 'be'
             # and 'bk', already folded above.
 
         elif macro_model_dimension == '2D':
             # For KL: 6 numbers. For Mindlin: 6 + 2 numbers (extra pair).
             # 'se' already includes membrane (3) + bending (3) after folding se[0] + sk[0].
-            writeFormat(fout, 'E'*6, se)
-            # If Mindlin/Reissner–Mindlin, append the extra 2 values.
-            if len(mindlin_extra) > 0:
+            if shell_model.lower() in ('mindlin','reissner-mindlin') and len(mindlin_extra) > 0:
                 pair = (mindlin_extra + [0.0, 0.0])[:2]
-                fout.write('\n')
-                writeFormat(fout, 'E'*2, pair)
+                all_vals = list(se) + list(pair)
+                fout.write(" ".join(str(float(x)) for x in all_vals) + "\n")
+            else:
+                fout.write(" ".join(str(float(x)) for x in se) + "\n")
 
         elif macro_model_dimension == '3D':
             # 6 numbers for 3D (strain or stress), already folded into 'e'
-            writeFormat(fout, 'E'*6, e)
+            fout.write(" ".join(str(float(x)) for x in e) + "\n")
 
         fout.write('\n')
         if analysis==1:
             writeFormat(fout, 'E', tm)
-
-
-    print('before try')
-
 
     #execute dehomogenization
     try:

--- a/scripts/py3/scLocalMain.py
+++ b/scripts/py3/scLocalMain.py
@@ -18,7 +18,11 @@ def localization(
         sg_name='', sc_input='', analysis=0, macro_model=3,
         load_measure=1,
         be='', bk='', se='', sk='', en='', es='',
-        tm=0.0, ap_flag=False):
+        sh2='',                    # extra 2 components for Mindlin: γ13 γ23 (strain) or N13 N23 (stress)
+        tm=0.0, ap_flag=False,
+        beam_model="Euler",        # Euler or Timoshenko (for 1D)
+        shell_model="Kirchhoff"    # Kirchhoff or Mindlin/Reissner–Mindlin (for 2D)
+    ):
     """
     Localization analysis for a SG model or a SwiftComp input file.
 
@@ -66,24 +70,39 @@ def localization(
     elif en != '' and es != '':
         e = en[0] + es[0]
 
+    # Handle extra Mindlin pair (γ13, γ23) or (N13, N23).
+    # Accept from explicit 'sh2' if provided; otherwise, fall back to es[0][:2] if user entered via es.
+    mindlin_extra = []
+    if isinstance(sh2, (list, tuple)) and len(sh2) > 0:
+        mindlin_extra = list(sh2[0])
+    elif isinstance(es, (list, tuple)) and len(es) > 0:
+        # If GUI provided γ13, γ23 (or N13, N23) via es for Mindlin, take the first two.
+        if isinstance(es[0], (list, tuple)) and len(es[0]) >= 2:
+            mindlin_extra = list(es[0][:2])
+
     mdb.customData.Repository('sgDehomoDataSets', SgDehomoData)
     
-    SCfileName, sc_input, analysis,  macro_model, macro_model_dimension, ap_flag=sgmodel_info(sgmodel_source=sgmodel_source, sg_name=sg_name, sc_input=sc_input,  analysis=analysis, macro_model=macro_model, ap_flag=ap_flag)
+    SCfileName, sc_input, analysis,  macro_model, macro_model_dimension, ap_flag = sgmodel_info(
+        sgmodel_source=sgmodel_source, sg_name=sg_name, sc_input=sc_input,
+        analysis=analysis, macro_model=macro_model, ap_flag=ap_flag)
 
     
 #-----------------------------------------------------------
     print(sc_input)
-    sgDehomoData_name=SCfileName
+    sgDehomoData_name = SCfileName
     sc_global = sc_input + r'.glb'
-    sc_input_sc=os.path.basename(sc_input)
+    sc_input_sc = os.path.basename(sc_input)
     # Check if there is a odb file with the destination name have already exist:
     checkDehoVisual(sc_input_sc, 'Dehomo')
 
 
     
-    sgDehomoData=mdb.customData.SgDehomoData(name=sgDehomoData_name)
-    sgDehomoData.createSgDehomoData(debug, sgmodel_source, sg_name,sc_input,analysis,macro_model,
-                    macro_displacement=tuple(v), macro_roatation=tuple(c), beam_strain=tuple(be), shell_strain=tuple(se),solid_strain=tuple(e), tm=tm)
+    sgDehomoData = mdb.customData.SgDehomoData(name=sgDehomoData_name)
+    sgDehomoData.createSgDehomoData(
+        debug, sgmodel_source, sg_name, sc_input, analysis, macro_model,
+        macro_displacement=tuple(v), macro_roatation=tuple(c),
+        beam_strain=tuple(be), shell_strain=tuple(se), solid_strain=tuple(e), tm=tm,
+        beam_model=beam_model)
     if info==1:
         print(('---> Create sgDehomoData: %s' % sg_name))
         print(('    mdb.customData.sgDehomoDataSets[\'%s\']' % sgDehomoData_name))
@@ -100,13 +119,18 @@ def localization(
         print('Macroscopic roatations')
         print(c)
         if macro_model_dimension=='1D':
-            print('beam macroscopic strain and curvatures :')
+            print('beam macroscopic strain and curvatures :' if load_measure==1 else 'beam generalized stress resultants :')
             print(be)
+            print('Beam model: %s' % beam_model)
         elif macro_model_dimension=='2D':
-            print('shell macroscopic strain and curvatures :')
+            print('shell macroscopic strain and curvatures :' if load_measure==1 else 'shell generalized stress resultants :')
             print(se)
+            print('Shell model: %s' % shell_model)
+            if shell_model.lower() in ('mindlin','reissner-mindlin','reissner–mindlin'):
+                print('Mindlin extra pair:')
+                print(mindlin_extra)
         elif macro_model_dimension=='3D':
-            print('3D solid macroscopic strain :')
+            print('3D solid macroscopic strain :' if load_measure==1 else '3D solid macroscopic stress :')
             print(e)
 
 
@@ -122,12 +146,28 @@ def localization(
         fout.write('\n')
         writeFormat(fout, 'd', [load_measure])
         fout.write('\n')
+
+        # Write generalized quantities by dimensional model
         if macro_model_dimension == '1D':
+            # be contains [e11, k11, k12, k13] OR for stress [F1, M1, M2, M3] if user entered that order
             writeFormat(fout, 'E'*4, be)
+            # For Timoshenko we don't need to force placeholders; GUI provides correct triplets in 'be'
+            # and 'bk', already folded above.
+
         elif macro_model_dimension == '2D':
+            # For KL: 6 numbers. For Mindlin: 6 + 2 numbers (extra pair).
+            # 'se' already includes membrane (3) + bending (3) after folding se[0] + sk[0].
             writeFormat(fout, 'E'*6, se)
+            # If Mindlin/Reissner–Mindlin, append the extra 2 values.
+            if len(mindlin_extra) > 0:
+                pair = (mindlin_extra + [0.0, 0.0])[:2]
+                fout.write('\n')
+                writeFormat(fout, 'E'*2, pair)
+
         elif macro_model_dimension == '3D':
+            # 6 numbers for 3D (strain or stress), already folded into 'e'
             writeFormat(fout, 'E'*6, e)
+
         fout.write('\n')
         if analysis==1:
             writeFormat(fout, 'E', tm)
@@ -168,4 +208,3 @@ def localization(
     print('Odb file creation time: %s' % str(visualTime))
 
     return
-

--- a/scripts/py3/scVisualMain.py
+++ b/scripts/py3/scVisualMain.py
@@ -14,6 +14,7 @@ import utilities_abq as uab
 from textRepr import *
 from UcheckDehoVisual import *
 import os.path
+import os, shutil
 
 # ==============================================================================
 #
@@ -91,9 +92,11 @@ def visualization(macro_model, ap_flag, sc_input):
     elem_connt_s9 = []
     
     elem_connt_c4  = []
+    elem_connt_c6  = []
     elem_connt_c10 = []
     elem_connt_c8  = []
     elem_connt_c20 = []
+    elem_connt_c15 = []
     
     elem_connt_b31_temp=[]
     elem_connt_b31 = []
@@ -150,10 +153,14 @@ def visualization(macro_model, ap_flag, sc_input):
                     elif len(line) >= 22:       # 3D element
                         if len(temp) == 5:
                             elem_connt_c4.append(tuple(temp))
+                        elif len(temp) == 7:   
+                            elem_connt_c6.append(tuple(temp))
                         elif len(temp) == 11:
                             elem_connt_c10.append(tuple(temp))
                         elif len(temp) == 9:
                             elem_connt_c8.append(tuple(temp))
+                        elif len(temp) == 16:  
+                            elem_connt_c15.append(tuple(temp))
                         elif len(temp) == 21:
                             elem_connt_c20.append(tuple(temp))
                     sect = line[1]                  # Read material sections
@@ -167,8 +174,10 @@ def visualization(macro_model, ap_flag, sc_input):
     elem_connt_s4.sort()
     elem_connt_s8.sort()
     elem_connt_c4.sort()
+    elem_connt_c6.sort()
     elem_connt_c10.sort()
     elem_connt_c8.sort()
+    elem_connt_c15.sort() 
     elem_connt_c20.sort()
     
     # 1D 
@@ -363,6 +372,27 @@ def visualization(macro_model, ap_flag, sc_input):
     odb_title = project_name
     odb_file_name = os.path.join(project_path, project_name + '.odb')
 
+    # Check if ODB already exists
+    if os.path.exists(odb_file_name):
+        print("--! Warning: ODB file already exists and will be overwritten.")
+        try:
+            # Try closing if it's open
+            try:
+                odb = openOdb(odb_file_name)
+                odb.close()
+            except:
+                pass
+
+            os.remove(odb_file_name)
+            aux_dir = odb_file_name + "_f"
+            if os.path.isdir(aux_dir):
+                shutil.rmtree(aux_dir)
+
+            print("--> Existing ODB deleted.")
+        except OSError as e:
+            print("--! Failed to delete existing ODB: {}".format(e))
+            sys.exit(1)
+    
     odb = Odb(name = odb_name, 
               analysisTitle = odb_title, 
               description = 'SwiftComp Dehomogenization', 
@@ -379,10 +409,15 @@ def visualization(macro_model, ap_flag, sc_input):
                         u_data, sg_strain, sg_stress, sn_strain, sn_stress, 
                         sgm_strain, sgm_stress, snm_strain, snm_stress)
     elif nsg == 3:
-        visualization3D(odb, project_name, node_coord, elem_connt_c4, elem_connt_c10, 
-                        elem_connt_c8, elem_connt_c20, elem_sectn, node_label, elem_label, 
-                        u_data, sg_strain, sg_stress, sn_strain, sn_stress, 
-                        sgm_strain, sgm_stress, snm_strain, snm_stress)
+        visualization3D(odb, project_name, node_coord,
+                        elem_connt_c4, elem_connt_c6,
+                        elem_connt_c8, elem_connt_c10,
+                        elem_connt_c15, elem_connt_c20,
+                        elem_sectn, node_label, elem_label,
+                        u_data, sg_strain, sg_stress,
+                        sn_strain, sn_stress,
+                        sgm_strain, sgm_stress,
+                        snm_strain, snm_stress)
     elif nsg == 1:
         visualization1D(odb, project_name, node_coord, elem_connt_b31, elem_sectn, node_label, elem_label, 
                         u_data, sg_strain, sg_stress, sn_strain, sn_stress)
@@ -910,9 +945,10 @@ def visualization2D(
 #
 # ==============================================================================
 
-def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt_c10, 
-                    elem_connt_c8, elem_connt_c20, elem_sectn, node_label, elem_label, 
-                    u_data, sg_strain, sg_stress, sn_strain, sn_stress, 
+def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt_c6,
+                    elem_connt_c8, elem_connt_c10, elem_connt_c15, elem_connt_c20,
+                    elem_sectn, node_label, elem_label,
+                    u_data, sg_strain, sg_stress, sn_strain, sn_stress,
                     sgm_strain, sgm_stress, snm_strain, snm_stress):
 
     # -----------------------
@@ -955,12 +991,18 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
     if elem_connt_c4 != []:
         elem_connt_c4 = tuple(elem_connt_c4)
         part_1.addElements(elementData = elem_connt_c4, type = 'C3D4', elementSetName = 'eSet-c3d4')
+    if elem_connt_c6 != []:
+        elem_connt_c6 = tuple(elem_connt_c6)
+        part_1.addElements(elementData = elem_connt_c6, type = 'C3D6', elementSetName = 'eSet-c3d6')
     if elem_connt_c10 != []:
         elem_connt_c10 = tuple(elem_connt_c10)
         part_1.addElements(elementData = elem_connt_c10, type = 'C3D10', elementSetName = 'eSet-c3d10')
     if elem_connt_c8 != []:
         elem_connt_c8 = tuple(elem_connt_c8)
         part_1.addElements(elementData = elem_connt_c8, type = 'C3D8', elementSetName = 'eSet-c3d8')
+    if elem_connt_c15 != []:
+        elem_connt_c15 = tuple(elem_connt_c15)
+        part_1.addElements(elementData = elem_connt_c15, type = 'C3D15', elementSetName = 'eSet-c3d15')
     if elem_connt_c20 != []:
         elem_connt_c20 = tuple(elem_connt_c20)
         part_1.addElements(elementData = elem_connt_c20, type = 'C3D20', elementSetName = 'eSet-c3d20')
@@ -1004,7 +1046,7 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
     
     # ---- GLOBAL COORDINATES ----
     print(' --> Importing strain and stress data under global coordinates...')
-    # Strains at integration points
+    """# Strains at integration points
     if sg_strain != []:
         print('  --> Strains at integration points...')
         s_field = frame_1.FieldOutput(
@@ -1038,7 +1080,7 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
             labels = elem_label, 
             data = sg_stress
             )
-        odb_vis.save()
+        odb_vis.save()"""
     
     # Strains at elemental nodes
     if sn_strain != []:
@@ -1079,7 +1121,7 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
     
     # ---- MATERIAL COORDINATES ----
     print(' --> Importing strain and stress data under material coordinates...')
-    # Strains at integration points
+    """# Strains at integration points
     if sgm_strain != []:
         print('  --> Strains at integration points...')
         s_field = frame_1.FieldOutput(
@@ -1113,7 +1155,7 @@ def visualization3D(odb_vis, project_name, node_coord, elem_connt_c4, elem_connt
             labels = elem_label, 
             data = sgm_stress
             )
-        odb_vis.save()
+        odb_vis.save()"""
     
     # Strains at elemental nodes
     if snm_strain != []:

--- a/scripts/py3/userDataSG.py
+++ b/scripts/py3/userDataSG.py
@@ -61,7 +61,10 @@ class SgDehomoData(CommandRegister):
     def createSgDehomoData(self, debug, sgmodel_source, sg_name, sc_input, 
                            analysis, macro_model, macro_displacement, 
                            macro_roatation, beam_strain, shell_strain, 
-                           solid_strain, tm=0.0):
+                           solid_strain, tm=0.0,
+                           load_measure=1,
+                           beam_model="Euler",
+                           shell_model="Kirchhoff"):
         
         if sgmodel_source == 1:
             self.sgmodel_source = 'fromSGmodel'
@@ -92,15 +95,18 @@ class SgDehomoData(CommandRegister):
             self.macro_model_dimension = str(macro_model) + 'D'
             self.analysis              = analysis
             
-        self.macro_displacement = macro_displacement #RegisteredTuple(macro_displacement)
-        self.macro_roatation    = macro_roatation #RegisteredTuple(macro_roatation)
+        self.macro_displacement = macro_displacement # RegisteredTuple(macro_displacement)
+        self.macro_roatation    = macro_roatation    # RegisteredTuple(macro_roatation)
+        self.load_measure       = load_measure       # 0: stress, 1: strain
         macro_model_dimension   = self.macro_model_dimension
         if macro_model_dimension == '1D':
-            self.macro_strain = beam_strain #RegisteredTuple(beam_strain)
+            self.macro_strain = beam_strain          # RegisteredTuple(beam_strain) or stress resultants slots
+            self.beam_model   = beam_model
         elif macro_model_dimension == '2D':
-            self.macro_strain = shell_strain #RegisteredTuple(shell_strain)
+            self.macro_strain = shell_strain         # RegisteredTuple(shell_strain) or stress resultants slots
+            self.shell_model  = shell_model
         elif macro_model_dimension == '3D':
-            self.macro_strain = solid_strain #RegisteredTuple(solid_strain)
+            self.macro_strain = solid_strain         # RegisteredTuple(solid_strain) or stress components
         
         if self.analysis == 1:
             self.temperature_increment = tm
@@ -109,4 +115,3 @@ class SgDehomoData(CommandRegister):
     
 mdb.customData.Repository('sgs', Sg)
 mdb.customData.Repository('sgDehomoDataSets', SgDehomoData)            
-        

--- a/scripts/py3/writeSCinput.py
+++ b/scripts/py3/writeSCinput.py
@@ -1,5 +1,4 @@
 import codecs
-import numpy as np
 from utilities import *
 # from parseAbaqusInput import *
 
@@ -91,43 +90,40 @@ def writeSCInput(
         # ----- Write nodal coordinates ------------------------------
         if nsg == 1:
             for n in n_coord:
-                writeFormat(fout, 'dE', n[[0, 3]])
+                writeFormat(fout, 'dE', [n[0], n[3]])
         elif nsg == 2:
             for n in n_coord:
-                # print n[[0, 2, 3]]
-                writeFormat(fout, 'dEE', n[[0, 2, 3]])
+                writeFormat(fout, 'dEE', [n[0], n[2], n[3]])
         elif nsg == 3:
             for n in n_coord:
-                writeFormat(fout, 'dEEE', n[[0, 1, 2, 3]])
+                writeFormat(fout, 'dEEE', [n[0], n[1], n[2], n[3]])
         fout.write('\n')
 
         # ----- Write element connectivities -------------------------
-        # eid_lid = {eid1: lid1, eid2: lid2, ...}
         for e in e_connt_2d:
-            e = np.insert(e, 1, eid_lid[e[0]])
-            writeFormat(fout, 'd'*11, e)
+            eid = e[0]
+            lid = eid_lid[eid]
+            row = [eid, lid] + list(e[1:])
+            writeFormat(fout, 'd'*11, row)
         for e in e_connt_3d:
-            e = np.insert(e, 1, eid_lid[e[0]])
-            writeFormat(fout, 'd'*22, e)
+            eid = e[0]
+            lid = eid_lid[eid]
+            row = [eid, lid] + list(e[1:])
+            writeFormat(fout, 'd'*22, row)
         fout.write('\n')
 
         # ----- Write local coordinates ------------------------------
-        for distr in distr_all:
-            eid = int(distr[0])
-            eid_all.remove(eid)
-            fout.write('{0:10d}'.format(eid))
-            writeFormat(fout, 'E'*9, distr[1:])
-        if len(eid_all) > 0:
-            a = [1.0, 0.0, 0.0]
-            b = [0.0, 1.0, 0.0]
-            c = [0.0, 0.0, 0.0]
-            for eid in eid_all:
-                writeFormat(fout, 'd'+'E'*9, [eid]+a+b+c)
-        fout.write('\n')
+        if distr_all and len(distr_all) > 0:
+            for distr in distr_all:
+                eid = int(distr[0])
+                if eid in eid_all:
+                    eid_all.remove(eid)
+                fout.write('{0:10d}'.format(eid))
+                writeFormat(fout, 'E'*9, distr[1:])
+            fout.write('\n')
 
         # ----- Write layer types ------------------------------------
         for lyt in layer_types:
-            # print lyt
             writeFormat(fout, 'ddE', lyt)
         fout.write('\n')
 
@@ -135,21 +131,21 @@ def writeSCInput(
         for mid, prop in list(materials.items()):
             writeFormat(fout, 'ddd', [mid, prop['isotropy'], prop['ntemp']])
             for i in range(prop['ntemp']):
-                # print prop['elastic'][:2]
-                writeFormat(fout, 'EE', prop['elastic'][i][:2])
+                elastic = prop['elastic'][i]
+                writeFormat(fout, 'EE', elastic[:2])
                 if prop['isotropy'] == 0:
-                    writeFormat(fout, 'EE', prop['elastic'][i][2:])
+                    writeFormat(fout, 'EE', elastic[2:])
                 elif prop['isotropy'] == 1:
-                    writeFormat(fout, 'EEE', prop['elastic'][i][2:5])
-                    writeFormat(fout, 'EEE', prop['elastic'][i][5:8])
-                    writeFormat(fout, 'EEE', prop['elastic'][i][8:11])
+                    writeFormat(fout, 'EEE', elastic[2:5])
+                    writeFormat(fout, 'EEE', elastic[5:8])
+                    writeFormat(fout, 'EEE', elastic[8:11])
                 elif prop['isotropy'] == 2:
-                    writeFormat(fout, 'E'*6, prop['elastic'][i][2:8])
-                    writeFormat(fout, 'E'*5, prop['elastic'][i][8:13])
-                    writeFormat(fout, 'E'*4, prop['elastic'][i][13:17])
-                    writeFormat(fout, 'E'*3, prop['elastic'][i][17:20])
-                    writeFormat(fout, 'E'*2, prop['elastic'][i][20:22])
-                    writeFormat(fout, 'E'*1, prop['elastic'][i][22:23])
+                    writeFormat(fout, 'E'*6, elastic[2:8])
+                    writeFormat(fout, 'E'*5, elastic[8:13])
+                    writeFormat(fout, 'E'*4, elastic[13:17])
+                    writeFormat(fout, 'E'*3, elastic[17:20])
+                    writeFormat(fout, 'E'*2, elastic[20:22])
+                    writeFormat(fout, 'E'*1, elastic[22:23])
                 fout.write('\n')
             fout.write('\n')
         fout.write('\n')


### PR DESCRIPTION
This is a major fix for homogenization. I also fixed some bugs in dehomogenization from the last pull request.

Homogenization

1) Added C3D6 and C3D15 element types. 

Added logics for handling C3D6 and C3D15 elements in homogenization logics using cae and inp files.

2) Added logics for reading "orientations" and "composite layups" from inp file

Implemented logic to parse and map composite layups.

3) Decommissioned numpy arrays

All array handling in parsing logics was converted to pure Python lists, which eliminated "VisibleDeprecationWarnings" and from ragged arrays (e.g., {{1,2},{3,4,5}}). Note that ragged arrays are no longer supported in NumPy.

4) Deleted logics for reading composite layup from the cae file

Because elemental orientations are not included in the cae file, the reader cannot obtain transformation matrix for each element. Writing my own logics to derive transformation matrix from composite layup needs a lot of work, which I am not able to do at the moment. It is recommended that user uses the inp file instead. The user can only use isotropic material if they want to use cae files.

5) Extensive error handling

Used raise ValueError() for unexpected exceptions, which tells users what is wrong with their input file. For example, if the user sets elemental orientation to global but has composite layup or orientation, the script will throw an error telling the user to set elemental orientation to local. This will prevent the user from getting incorrect results because incorrect sc file is generated.

6) Temporarily disabled orientations

Orientations are currently not supported. It might be available in future updates.

7) Renumbering

Abaqus may not number the element in a strict descending order starting from 1 (e.g., 3, 4, 7). The script implements a logic to renumber element from the first to the last element.

8) Asserting elemental orientation for isotropic materials

When the user sets the elemental orientation to Local (trans_flag = 1), the script will append identity matrix. Otherwise SwiftComp will complain about lacking elemental orientations.

9) Other bug fixes

Added C3D20R to 3D 20-node type. Before this update the script could not write element data because it only recognizes C3D20 as the only 3D 20-node element type. Other small changes can be seen in the scripts with comments.

Dehomogenization

Bug fixes:

1) Fixed malformed glb file 

In the glb file generated in the Dehomogenization panel, the last 2 strains/stresses for the Timoshenko model were missing, and Mindlin model had the last 2 strains/stresses at a new line. Those have been corrected in this update.

2) Determine model type using sc file to prevent misclicks

Added two new arguments to sgmodel_info() to get the dimension of the model (1D/2D/3D) and model type (Kirchhoff/Mindlin/Euler/Timoshenko). If the user selected a model by mistake, say, the actual model is Timoshenko model (1D) but the user selected Euler model, the plug-in will show an error telling the user selected the wrong model. This also applies to wrong dimensions, like selecting a 2D model for a 1D beam model. This will prevent the program from crashing because wrong model type is selected.

For testing:

Test any 3D SG using 3D elements, including a mix of elements (like hex and wedge elements, which can be produced using a hex-dominated mesh). You can use isotropic or orthotropic (using Engineering constants in Abaqus) with Composite Layups (NOT Orientations) or a mix of isotropic and orthotropic. Homogenize using 1D beam or 3D model. You can also test your examples with dehomogenization after homogenization. They should all work.